### PR TITLE
Add confirmation UI, chaos mode, restore command, and category autocomplete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ────────────────────────────────────────────────────────────────
-FROM rust:1.76-slim AS builder
+FROM rust:1.95-slim AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ categories, and name-pool state survive bot restarts.
 | Feature | Details |
 |---------|---------|
 | **Slash commands** | Registered globally; work in every server the bot joins |
-| **Randomize everyone** | `/randomize` renames every non-bot member in the server |
+| **Randomize everyone** | `/randomize` renames every non-bot member (behind a confirmation button) |
+| **Full chaos mode** | `/randomize chaos:true` gives every member a name from a *different* random category |
+| **Undo** | `/restore [user]` puts members back to their pre-bot nickname |
+| **Category autocomplete** | The `category` option autocompletes built-in **and** custom categories |
 | **Rename one user** | `/nick @user [category] [specific_name]` renames a single member |
 | **Context-menu command** | Right-click any user → *Assign Random Nick* (modal lets you pick category and/or a specific name) |
 | **Without-replacement draws** | The full pool is exhausted before any name repeats |
@@ -32,9 +35,18 @@ categories, and name-pool state survive bot restarts.
 
 ## Slash commands
 
-### `/randomize [category]`
+### `/randomize [category] [chaos]`
 Assigns a random nickname from `category` to every non-bot member.  
 If `category` is omitted, a random category is chosen.  
+- `chaos` — when `true`, every member gets a name from a *different* random category (the `category` argument is ignored).  
+A confirmation button is shown before any member is renamed.  
+**Requires:** Manage Nicknames permission.
+
+### `/restore [user]`
+Restores members to the nickname they had **before** the bot first changed it
+(read from recorded history).  Omit `user` to restore everyone the bot has
+renamed; pass a `user` to restore just that person.  This is the undo for
+`/randomize`.  
 **Requires:** Manage Nicknames permission.
 
 ### `/nick <user> [category] [specific_name]`
@@ -101,6 +113,11 @@ A modal lets you optionally specify:
 | `planets` | Mercury, Saturn, Pluto… |
 | `colors` | Crimson, Cerulean, Chartreuse… |
 | `fruits` | Dragonfruit, Persimmon, Kumquat… |
+
+The built-in lists live in [`src/categories.json`](src/categories.json) and are
+embedded into the binary at compile time — edit that file and rebuild to change
+them (no database or runtime file needed). Custom categories remain fully
+runtime-managed via `/categories`.
 
 ---
 

--- a/src/categories.json
+++ b/src/categories.json
@@ -1,0 +1,46 @@
+{
+  "scientists": [
+    "Einstein", "Newton", "Darwin", "Curie", "Tesla", "Feynman", "Hawking", "Bohr",
+    "Faraday", "Turing", "Heisenberg", "Schrodinger", "Planck", "Dirac", "Fermi",
+    "Oppenheimer", "Lovelace", "Noether", "Ramanujan", "Euler"
+  ],
+  "elements": [
+    "Hydrogen", "Helium", "Lithium", "Carbon", "Nitrogen", "Oxygen", "Neon",
+    "Sodium", "Magnesium", "Aluminum", "Silicon", "Phosphorus", "Sulfur", "Chlorine",
+    "Argon", "Potassium", "Calcium", "Iron", "Copper", "Zinc", "Silver", "Gold",
+    "Mercury", "Lead", "Uranium"
+  ],
+  "chemical_compounds": [
+    "Caffeine", "Aspirin", "Serotonin", "Dopamine", "Adrenaline", "Glucose",
+    "Ethanol", "Acetone", "Benzene", "Toluene", "Acetylene", "Propane", "Methane",
+    "Ozone", "Ammonia", "Sucrose", "Fructose", "Lactose", "Galactose", "Maltose"
+  ],
+  "amusement_parks": [
+    "Disneyland", "Six Flags", "Cedar Point", "Universal Studios", "Busch Gardens",
+    "Knott's Berry Farm", "Hersheypark", "SeaWorld", "Dollywood", "Alton Towers",
+    "Europa Park", "PortAventura", "Thorpe Park", "Legoland", "Dreamworld",
+    "Tivoli Gardens", "Phantasialand", "Holiday World", "Carowinds", "Adventureland"
+  ],
+  "dinosaurs": [
+    "T-Rex", "Velociraptor", "Triceratops", "Stegosaurus", "Brachiosaurus",
+    "Ankylosaurus", "Pterodactyl", "Diplodocus", "Allosaurus", "Spinosaurus",
+    "Iguanodon", "Pachycephalosaurus", "Parasaurolophus", "Gallimimus",
+    "Carnotaurus", "Dilophosaurus", "Ceratosaurus", "Compsognathus", "Maiasaura",
+    "Oviraptor"
+  ],
+  "planets": [
+    "Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune",
+    "Pluto", "Ceres", "Eris", "Makemake", "Haumea", "Sedna", "Quaoar"
+  ],
+  "colors": [
+    "Crimson", "Scarlet", "Vermilion", "Tangerine", "Amber", "Chartreuse",
+    "Viridian", "Cerulean", "Cobalt", "Indigo", "Violet", "Magenta", "Fuchsia",
+    "Turquoise", "Periwinkle", "Sienna", "Ochre", "Umber", "Sepia", "Ecru"
+  ],
+  "fruits": [
+    "Mango", "Papaya", "Persimmon", "Pomegranate", "Lychee", "Dragonfruit",
+    "Starfruit", "Jackfruit", "Durian", "Guava", "Passion Fruit", "Tamarind",
+    "Kumquat", "Rambutan", "Soursop", "Ackee", "Feijoa", "Cherimoya", "Langsat",
+    "Salak"
+  ]
+}

--- a/src/commands/categories.rs
+++ b/src/commands/categories.rs
@@ -25,12 +25,8 @@ pub fn parse_category_csv(text: &str) -> (Vec<(String, Vec<String>)>, Vec<String
             continue;
         }
 
-        let mut fields: Vec<&str> = line.split(',').collect();
-        if fields.is_empty() {
-            continue;
-        }
-
-        let raw_key = fields.remove(0).trim();
+        let mut fields = line.split(',');
+        let raw_key = fields.next().unwrap_or("").trim();
         let key = raw_key.to_lowercase();
 
         if !valid_category_key(&key) {
@@ -43,7 +39,6 @@ pub fn parse_category_csv(text: &str) -> (Vec<(String, Vec<String>)>, Vec<String
         }
 
         let names: Vec<String> = fields
-            .iter()
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect();

--- a/src/commands/categories.rs
+++ b/src/commands/categories.rs
@@ -6,7 +6,7 @@ use crate::{data, Context, Error};
 /// only letters, digits, or underscores.
 fn valid_category_key(key: &str) -> bool {
     !key.is_empty()
-        && key.chars().next().is_some_and(|c| c.is_alphabetic())
+        && key.chars().next().is_some_and(char::is_alphabetic)
         && key.chars().all(|c| c.is_alphanumeric() || c == '_')
 }
 
@@ -220,10 +220,10 @@ pub async fn remove(
             let _ = crate::db::clear_used_names(&db, gid, Some(&k)).await;
         });
 
-        ctx.say(format!("✅ Removed custom category **{}**.", key))
+        ctx.say(format!("✅ Removed custom category **{key}**."))
             .await?;
     } else {
-        ctx.say(format!("❌ No custom category named `{}` found.", key))
+        ctx.say(format!("❌ No custom category named `{key}` found."))
             .await?;
     }
 
@@ -294,7 +294,7 @@ pub async fn import(
     if !added.is_empty() {
         let summary: Vec<String> = added
             .iter()
-            .map(|(cat, n)| format!("• **{}** ({} name(s))", cat, n))
+            .map(|(cat, n)| format!("• **{cat}** ({n} name(s))"))
             .collect();
         reply.push_str(&format!(
             "✅ Imported **{}** categor{}:\n{}",

--- a/src/commands/categories.rs
+++ b/src/commands/categories.rs
@@ -6,8 +6,57 @@ use crate::{data, Context, Error};
 /// only letters, digits, or underscores.
 fn valid_category_key(key: &str) -> bool {
     !key.is_empty()
-        && key.chars().next().map_or(false, |c| c.is_alphabetic())
+        && key.chars().next().is_some_and(|c| c.is_alphabetic())
         && key.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Parse a CSV import body into `(categories, line_errors)`.
+///
+/// Each non-blank, non-`#` line is `category_name,name1,name2,…`.  Category
+/// names are lower-cased; surrounding whitespace on every field is trimmed and
+/// empty names are dropped.  This is pure (no I/O) so it can be unit-tested.
+pub fn parse_category_csv(text: &str) -> (Vec<(String, Vec<String>)>, Vec<String>) {
+    let mut added: Vec<(String, Vec<String>)> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for (line_no, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let mut fields: Vec<&str> = line.split(',').collect();
+        if fields.is_empty() {
+            continue;
+        }
+
+        let raw_key = fields.remove(0).trim();
+        let key = raw_key.to_lowercase();
+
+        if !valid_category_key(&key) {
+            errors.push(format!(
+                "Line {}: invalid category name `{}` (must start with a letter, alphanumeric and underscores only)",
+                line_no + 1,
+                raw_key
+            ));
+            continue;
+        }
+
+        let names: Vec<String> = fields
+            .iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if names.is_empty() {
+            errors.push(format!("Line {}: category `{}` has no names", line_no + 1, key));
+            continue;
+        }
+
+        added.push((key, names));
+    }
+
+    (added, errors)
 }
 
 // ── /categories (parent with four sub-commands) ──────────────────────────────
@@ -146,19 +195,21 @@ pub async fn remove(
     #[description = "Name of the custom category to remove"] name: String,
 ) -> Result<(), Error> {
     let key = name.to_lowercase();
-    let builtin = data::builtin_category_names();
-
-    if builtin.contains(&key) {
-        ctx.say("❌ Built-in categories cannot be removed.").await?;
-        return Ok(());
-    }
-
     let guild_id = ctx.guild_id().unwrap();
+
+    // A custom category that *shadows* a built-in name is still removable —
+    // removing it simply restores the built-in. Only reject when there is no
+    // custom category of this name at all and the name belongs to a built-in.
     let removed = {
         let mut data = ctx.data().write_state().await;
         let gs = data.guild_mut(guild_id);
         gs.remove_custom_category(&key)
     };
+
+    if !removed && data::builtin_category_names().contains(&key) {
+        ctx.say("❌ Built-in categories cannot be removed.").await?;
+        return Ok(());
+    }
 
     if removed {
         // Persist to DB (best-effort)
@@ -215,43 +266,10 @@ pub async fn import(
         .map_err(|_| "❌ File is not valid UTF-8.")?;
 
     let guild_id = ctx.guild_id().unwrap();
+    let (parsed, errors) = parse_category_csv(&text);
+
     let mut added: Vec<(String, usize)> = Vec::new();
-    let mut errors: Vec<String> = Vec::new();
-
-    for (line_no, line) in text.lines().enumerate() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        let mut fields: Vec<&str> = line.split(',').collect();
-        if fields.is_empty() {
-            continue;
-        }
-
-        let raw_key = fields.remove(0).trim();
-        let key = raw_key.to_lowercase();
-
-        if !valid_category_key(&key) {
-            errors.push(format!(
-                "Line {}: invalid category name `{}` (must start with a letter, alphanumeric and underscores only)",
-                line_no + 1,
-                raw_key
-            ));
-            continue;
-        }
-
-        let names: Vec<String> = fields
-            .iter()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        if names.is_empty() {
-            errors.push(format!("Line {}: category `{}` has no names", line_no + 1, key));
-            continue;
-        }
-
+    for (key, names) in parsed {
         let count = names.len();
 
         // Update in-memory state
@@ -262,7 +280,7 @@ pub async fn import(
             gs.reset_pool(Some(&key));
         }
 
-        // Persist to DB (best-effort, inside the loop)
+        // Persist to DB (best-effort)
         let db = ctx.data().db.clone();
         let gid = guild_id;
         let k = key.clone();
@@ -304,4 +322,101 @@ pub async fn import(
 
     ctx.say(reply).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── valid_category_key ────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_key_simple() {
+        assert!(valid_category_key("scientists"));
+        assert!(valid_category_key("my_cat_2"));
+        assert!(valid_category_key("a"));
+    }
+
+    #[test]
+    fn invalid_key_empty() {
+        assert!(!valid_category_key(""));
+    }
+
+    #[test]
+    fn invalid_key_starts_with_digit_or_underscore() {
+        assert!(!valid_category_key("2cool"));
+        assert!(!valid_category_key("_hidden"));
+    }
+
+    #[test]
+    fn invalid_key_with_spaces_or_punctuation() {
+        assert!(!valid_category_key("my cat"));
+        assert!(!valid_category_key("cat-name"));
+        assert!(!valid_category_key("cat!"));
+    }
+
+    // ── parse_category_csv ────────────────────────────────────────────────────
+
+    #[test]
+    fn csv_parses_basic_rows() {
+        let (cats, errs) = parse_category_csv("scientists,Einstein,Newton\nplanets,Mars,Venus");
+        assert!(errs.is_empty());
+        assert_eq!(cats.len(), 2);
+        assert_eq!(cats[0].0, "scientists");
+        assert_eq!(cats[0].1, vec!["Einstein", "Newton"]);
+        assert_eq!(cats[1].0, "planets");
+    }
+
+    #[test]
+    fn csv_lowercases_keys_and_trims_fields() {
+        let (cats, _) = parse_category_csv("  Heroes , Batman ,  Robin ");
+        assert_eq!(cats[0].0, "heroes");
+        assert_eq!(cats[0].1, vec!["Batman", "Robin"]);
+    }
+
+    #[test]
+    fn csv_skips_comments_and_blanks() {
+        let (cats, errs) = parse_category_csv("# a comment\n\n   \nheroes,Batman");
+        assert!(errs.is_empty());
+        assert_eq!(cats.len(), 1);
+        assert_eq!(cats[0].0, "heroes");
+    }
+
+    #[test]
+    fn csv_reports_invalid_key() {
+        let (cats, errs) = parse_category_csv("2bad,Foo,Bar");
+        assert!(cats.is_empty());
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("Line 1"));
+    }
+
+    #[test]
+    fn csv_reports_category_with_no_names() {
+        let (cats, errs) = parse_category_csv("empty,,, ,");
+        assert!(cats.is_empty());
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("no names"));
+    }
+
+    #[test]
+    fn csv_handles_crlf_line_endings() {
+        let (cats, errs) = parse_category_csv("heroes,Batman\r\nvillains,Joker\r\n");
+        assert!(errs.is_empty());
+        assert_eq!(cats.len(), 2);
+        assert_eq!(cats[1].1, vec!["Joker"]);
+    }
+
+    #[test]
+    fn csv_mixed_valid_and_invalid_lines() {
+        let (cats, errs) = parse_category_csv("good,A,B\n3bad,C\nalso_good,D");
+        assert_eq!(cats.len(), 2);
+        assert_eq!(errs.len(), 1);
+    }
+
+    #[test]
+    fn csv_empty_input_yields_nothing() {
+        let (cats, errs) = parse_category_csv("");
+        assert!(cats.is_empty());
+        assert!(errs.is_empty());
+    }
 }

--- a/src/commands/categories.rs
+++ b/src/commands/categories.rs
@@ -44,7 +44,11 @@ pub fn parse_category_csv(text: &str) -> (Vec<(String, Vec<String>)>, Vec<String
             .collect();
 
         if names.is_empty() {
-            errors.push(format!("Line {}: category `{}` has no names", line_no + 1, key));
+            errors.push(format!(
+                "Line {}: category `{}` has no names",
+                line_no + 1,
+                key
+            ));
             continue;
         }
 
@@ -245,8 +249,7 @@ pub async fn remove(
 )]
 pub async fn import(
     ctx: Context<'_>,
-    #[description = "CSV file (each row: category_name,name1,name2,…)"]
-    file: serenity::Attachment,
+    #[description = "CSV file (each row: category_name,name1,name2,…)"] file: serenity::Attachment,
 ) -> Result<(), Error> {
     ctx.defer().await?;
 
@@ -257,8 +260,7 @@ pub async fn import(
     }
 
     let bytes = file.download().await?;
-    let text = String::from_utf8(bytes)
-        .map_err(|_| "❌ File is not valid UTF-8.")?;
+    let text = String::from_utf8(bytes).map_err(|_| "❌ File is not valid UTF-8.")?;
 
     let guild_id = ctx.guild_id().unwrap();
     let (parsed, errors) = parse_category_csv(&text);

--- a/src/commands/context_menu.rs
+++ b/src/commands/context_menu.rs
@@ -85,7 +85,7 @@ pub async fn assign_random_nick(
         match result {
             Ok(n) => n,
             Err(e) => {
-                ctx.say(format!("❌ {}", e)).await?;
+                ctx.say(format!("❌ {e}")).await?;
                 return Ok(());
             }
         }

--- a/src/commands/context_menu.rs
+++ b/src/commands/context_menu.rs
@@ -1,6 +1,8 @@
 use poise::serenity_prelude as serenity;
 
-use crate::commands::randomize::{escape_mentions, resolve_category, truncate_nick};
+use crate::commands::randomize::{
+    escape_mentions, nick_edit_failure_message, resolve_category, truncate_nick,
+};
 use crate::{Data, Error};
 
 /// Modal shown when a user right-clicks → **Assign Random Nick**.
@@ -39,6 +41,10 @@ pub async fn assign_random_nick(
         Some(m) => m,
         None => return Ok(()), // user dismissed
     };
+
+    // The modal submission opens a fresh interaction; defer so the member
+    // fetch + edit below can't blow the 3-second response window.
+    ctx.defer().await?;
 
     // Normalise inputs
     let cat_input = category.as_deref().map(str::trim).filter(|s| !s.is_empty());
@@ -90,9 +96,19 @@ pub async fn assign_random_nick(
     let member = guild_id.member(&http, user.id).await?;
     let old_nick = member.nick.clone();
 
-    guild_id
+    if let Err(e) = guild_id
         .edit_member(&http, user.id, serenity::EditMember::new().nickname(&nick))
+        .await
+    {
+        tracing::warn!("nick edit failed for {} in {}: {:?}", user.name, guild_id, e);
+        ctx.send(
+            poise::CreateReply::default()
+                .content(nick_edit_failure_message(&user.name))
+                .allowed_mentions(serenity::CreateAllowedMentions::new()),
+        )
         .await?;
+        return Ok(());
+    }
 
     let (total_ch, bulk_ct) = {
         let mut data = ctx.data.write_state().await;

--- a/src/commands/context_menu.rs
+++ b/src/commands/context_menu.rs
@@ -37,7 +37,10 @@ pub async fn assign_random_nick(
 ) -> Result<(), Error> {
     // Show the modal to optionally pick a category / specific name
     let modal = poise::execute_modal(ctx, None::<NickModal>, None).await?;
-    let NickModal { category, specific_name } = match modal {
+    let NickModal {
+        category,
+        specific_name,
+    } = match modal {
         Some(m) => m,
         None => return Ok(()), // user dismissed
     };
@@ -48,7 +51,10 @@ pub async fn assign_random_nick(
 
     // Normalise inputs
     let cat_input = category.as_deref().map(str::trim).filter(|s| !s.is_empty());
-    let name_input = specific_name.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let name_input = specific_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
 
     let guild_id = ctx.guild_id().unwrap();
     let http = ctx.serenity_context().http.clone();
@@ -100,7 +106,12 @@ pub async fn assign_random_nick(
         .edit_member(&http, user.id, serenity::EditMember::new().nickname(&nick))
         .await
     {
-        tracing::warn!("nick edit failed for {} in {}: {:?}", user.name, guild_id, e);
+        tracing::warn!(
+            "nick edit failed for {} in {}: {:?}",
+            user.name,
+            guild_id,
+            e
+        );
         ctx.send(
             poise::CreateReply::default()
                 .content(nick_edit_failure_message(&user.name))
@@ -134,23 +145,23 @@ pub async fn assign_random_nick(
         let cn = cat_name.clone();
         tokio::spawn(async move {
             let _ = crate::db::add_used_name(&db, gid, &cn, &nn).await;
-            let _ = crate::db::insert_nick_change(&db, gid, uid, &un, old.as_deref(), &nn, &cn).await;
+            let _ =
+                crate::db::insert_nick_change(&db, gid, uid, &un, old.as_deref(), &nn, &cn).await;
             let _ = crate::db::upsert_guild_stats(&db, gid, total_ch, bulk_ct).await;
             let _ = crate::db::increment_category_usage(&db, gid, &cn).await;
         });
     }
 
     let safe_nick = escape_mentions(&new_nick);
-    ctx
-        .send(
-            poise::CreateReply::default()
-                .content(format!(
-                    "✅ Renamed **{}** to **{}** (from the **{}** category).",
-                    user.name, safe_nick, cat_name
-                ))
-                .allowed_mentions(serenity::CreateAllowedMentions::new()),
-        )
-        .await?;
+    ctx.send(
+        poise::CreateReply::default()
+            .content(format!(
+                "✅ Renamed **{}** to **{}** (from the **{}** category).",
+                user.name, safe_nick, cat_name
+            ))
+            .allowed_mentions(serenity::CreateAllowedMentions::new()),
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -22,12 +22,7 @@ pub async fn history(
                     .await?;
                 return Ok(());
             }
-            Some(gs) => gs
-                .history
-                .iter()
-                .take(limit)
-                .cloned()
-                .collect::<Vec<_>>(),
+            Some(gs) => gs.history.iter().take(limit).cloned().collect::<Vec<_>>(),
         }
     };
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod history;
 pub mod nick;
 pub mod randomize;
 pub mod reset;
+pub mod restore;
 pub mod stats;
 
 use crate::{Data, Error};
@@ -17,6 +18,7 @@ pub fn all_commands() -> Vec<poise::Command<Data, Error>> {
         stats::stats(),
         history::history(),
         reset::reset_pool(),
+        restore::restore(),
         context_menu::assign_random_nick(),
     ]
 }

--- a/src/commands/nick.rs
+++ b/src/commands/nick.rs
@@ -75,7 +75,12 @@ pub async fn nick(
         .edit_member(&http, user.id, serenity::EditMember::new().nickname(&nick))
         .await
     {
-        tracing::warn!("nick edit failed for {} in {}: {:?}", user.name, guild_id, e);
+        tracing::warn!(
+            "nick edit failed for {} in {}: {:?}",
+            user.name,
+            guild_id,
+            e
+        );
         ctx.say(nick_edit_failure_message(&user.name)).await?;
         return Ok(());
     }
@@ -104,7 +109,8 @@ pub async fn nick(
         let cn = cat_name.clone();
         tokio::spawn(async move {
             let _ = crate::db::add_used_name(&db, gid, &cn, &nn).await;
-            let _ = crate::db::insert_nick_change(&db, gid, uid, &un, old.as_deref(), &nn, &cn).await;
+            let _ =
+                crate::db::insert_nick_change(&db, gid, uid, &un, old.as_deref(), &nn, &cn).await;
             let _ = crate::db::upsert_guild_stats(&db, gid, total_ch, bulk_ct).await;
             let _ = crate::db::increment_category_usage(&db, gid, &cn).await;
         });

--- a/src/commands/nick.rs
+++ b/src/commands/nick.rs
@@ -57,7 +57,7 @@ pub async fn nick(
         match result {
             Ok(n) => n,
             Err(e) => {
-                ctx.say(format!("❌ {}", e)).await?;
+                ctx.say(format!("❌ {e}")).await?;
                 return Ok(());
             }
         }

--- a/src/commands/nick.rs
+++ b/src/commands/nick.rs
@@ -1,6 +1,8 @@
 use poise::serenity_prelude as serenity;
 
-use crate::commands::randomize::{escape_mentions, resolve_category, truncate_nick};
+use crate::commands::randomize::{
+    escape_mentions, nick_edit_failure_message, resolve_category, truncate_nick,
+};
 use crate::{Context, Error};
 
 /// Assign a random (or specific) nickname to a specific user.
@@ -16,10 +18,13 @@ pub async fn nick(
     ctx: Context<'_>,
     #[description = "The user to rename"] user: serenity::User,
     #[description = "Category to pick a name from (omit for a random category)"]
+    #[autocomplete = "crate::commands::randomize::autocomplete_category"]
     category: Option<String>,
     #[description = "A specific name to assign (omit to pick randomly from the category)"]
     specific_name: Option<String>,
 ) -> Result<(), Error> {
+    ctx.defer().await?;
+
     let guild_id = ctx.guild_id().unwrap();
     let http = ctx.serenity_context().http.clone();
 
@@ -66,9 +71,14 @@ pub async fn nick(
     let nick = truncate_nick(&new_nick).to_string();
     let old_nick = member.nick.clone();
 
-    guild_id
+    if let Err(e) = guild_id
         .edit_member(&http, user.id, serenity::EditMember::new().nickname(&nick))
-        .await?;
+        .await
+    {
+        tracing::warn!("nick edit failed for {} in {}: {:?}", user.name, guild_id, e);
+        ctx.say(nick_edit_failure_message(&user.name)).await?;
+        return Ok(());
+    }
 
     let (total_ch, bulk_ct) = {
         let mut data = ctx.data().write_state().await;

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -33,7 +33,8 @@ pub async fn randomize(
     let member_count = members.iter().filter(|m| !m.user.bot).count();
 
     if member_count == 0 {
-        ctx.say("There are no non-bot members to randomize.").await?;
+        ctx.say("There are no non-bot members to randomize.")
+            .await?;
         return Ok(());
     }
 
@@ -94,13 +95,19 @@ pub async fn randomize(
 
     let confirmed = match interaction {
         Some(mci) if mci.data.custom_id == confirm_id => {
-            mci.create_response(ctx.serenity_context(), serenity::CreateInteractionResponse::Acknowledge)
-                .await?;
+            mci.create_response(
+                ctx.serenity_context(),
+                serenity::CreateInteractionResponse::Acknowledge,
+            )
+            .await?;
             true
         }
         Some(mci) => {
-            mci.create_response(ctx.serenity_context(), serenity::CreateInteractionResponse::Acknowledge)
-                .await?;
+            mci.create_response(
+                ctx.serenity_context(),
+                serenity::CreateInteractionResponse::Acknowledge,
+            )
+            .await?;
             false
         }
         None => false,
@@ -277,7 +284,11 @@ pub async fn randomize(
             )
             .await
         {
-            tracing::warn!("Failed to send randomize summary to channel {}: {:?}", channel_id, e);
+            tracing::warn!(
+                "Failed to send randomize summary to channel {}: {:?}",
+                channel_id,
+                e
+            );
         }
     });
 
@@ -320,7 +331,10 @@ pub fn resolve_category(
         let available = {
             let mut keys: Vec<&String> = categories.keys().collect();
             keys.sort();
-            keys.iter().map(|k| format!("`{}`", k)).collect::<Vec<_>>().join(", ")
+            keys.iter()
+                .map(|k| format!("`{}`", k))
+                .collect::<Vec<_>>()
+                .join(", ")
         };
         Err(format!("Unknown category `{}`. Available: {}", req, available).into())
     } else {
@@ -508,7 +522,9 @@ mod tests {
     #[test]
     fn resolve_category_unknown_name_lists_available() {
         let cats = sample_categories();
-        let err = resolve_category(&cats, Some("nope")).unwrap_err().to_string();
+        let err = resolve_category(&cats, Some("nope"))
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("scientists"));
         assert!(err.contains("planets"));
     }

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -61,7 +61,7 @@ pub async fn randomize(
     };
 
     let scope_label = match &resolved {
-        Some((name, _)) => format!("the **{}** category", name),
+        Some((name, _)) => format!("the **{name}** category"),
         None => "**random categories** (full chaos)".to_string(),
     };
 
@@ -72,9 +72,8 @@ pub async fn randomize(
         .send(
             poise::CreateReply::default()
                 .content(format!(
-                    "⚠️ This will rename **{}** member(s) using {}.\nThis cannot be \
-                     automatically undone except via `/restore`. Proceed?",
-                    member_count, scope_label
+                    "⚠️ This will rename **{member_count}** member(s) using {scope_label}.\nThis cannot be \
+                     automatically undone except via `/restore`. Proceed?"
                 ))
                 .components(vec![serenity::CreateActionRow::Buttons(vec![
                     serenity::CreateButton::new(&confirm_id)
@@ -90,7 +89,7 @@ pub async fn randomize(
     let interaction = serenity::ComponentInteractionCollector::new(ctx)
         .author_id(ctx.author().id)
         .message_id(prompt.message().await?.id)
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_mins(1))
         .await;
 
     let confirmed = match interaction {
@@ -156,12 +155,9 @@ pub async fn randomize(
             .iter()
             .filter(|m| !m.user.bot)
             .filter_map(|m| {
-                let (cat, names) = match &resolved {
-                    Some((c, n)) => (c.clone(), n.clone()),
-                    None => {
-                        let k = chaos_keys.choose(&mut rng)?;
-                        (k.to_string(), categories[*k].clone())
-                    }
+                let (cat, names) = if let Some((c, n)) = &resolved { (c.clone(), n.clone()) } else {
+                    let k = chaos_keys.choose(&mut rng)?;
+                    ((*k).clone(), categories[*k].clone())
                 };
                 gs.pick_name(&cat, &names).map(|new_nick| Assignment {
                     user_id: m.user.id,
@@ -194,8 +190,7 @@ pub async fn randomize(
             ctx,
             poise::CreateReply::default()
                 .content(format!(
-                    "🎲 Randomizing **{}** member(s) using {} — this may take a moment…",
-                    total, scope_label
+                    "🎲 Randomizing **{total}** member(s) using {scope_label} — this may take a moment…"
                 ))
                 .components(vec![]),
         )
@@ -272,8 +267,7 @@ pub async fn randomize(
             "Background randomize task completed"
         );
         let summary = format!(
-            "✅ Randomization complete! Changed: **{}** | ❌ Skipped/errors: **{}**",
-            changed, errors
+            "✅ Randomization complete! Changed: **{changed}** | ❌ Skipped/errors: **{errors}**"
         );
         if let Err(e) = channel_id
             .send_message(
@@ -332,11 +326,11 @@ pub fn resolve_category(
             let mut keys: Vec<&String> = categories.keys().collect();
             keys.sort();
             keys.iter()
-                .map(|k| format!("`{}`", k))
+                .map(|k| format!("`{k}`"))
                 .collect::<Vec<_>>()
                 .join(", ")
         };
-        Err(format!("Unknown category `{}`. Available: {}", req, available).into())
+        Err(format!("Unknown category `{req}`. Available: {available}").into())
     } else {
         use rand::seq::IteratorRandom;
         let mut rng = rand::thread_rng();

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -120,9 +120,31 @@ pub async fn randomize(
 
     // ── Assign names (without-replacement draw, holding write lock briefly) ────
     // Each tuple is (member, new_nick, category_used).
-    let assignments: Vec<(serenity::Member, String, String)> = {
+    // Only the fields we actually need downstream — avoids cloning the whole
+    // (large) serenity::Member per member.
+    struct Assignment {
+        user_id: serenity::UserId,
+        user_name: String,
+        old_nick: Option<String>,
+        new_nick: String,
+        category: String,
+    }
+
+    let assignments: Vec<Assignment> = {
+        // In chaos mode collect the category keys once (O(C)) so per-member
+        // selection is O(1) instead of O(C) per member.
+        let chaos_keys: Vec<&String> = if resolved.is_none() {
+            categories.keys().collect()
+        } else {
+            Vec::new()
+        };
+
         let mut data = ctx.data().write_state().await;
         let gs = data.guild_mut(guild_id);
+        // Created after the lock is held and never kept across an `.await`
+        // (ThreadRng is !Send); the closure below contains no await points.
+        use rand::seq::SliceRandom;
+        let mut rng = rand::thread_rng();
         members
             .iter()
             .filter(|m| !m.user.bot)
@@ -130,21 +152,29 @@ pub async fn randomize(
                 let (cat, names) = match &resolved {
                     Some((c, n)) => (c.clone(), n.clone()),
                     None => {
-                        use rand::seq::IteratorRandom;
-                        let mut rng = rand::thread_rng();
-                        let (k, v) = categories.iter().choose(&mut rng)?;
-                        (k.clone(), v.clone())
+                        let k = chaos_keys.choose(&mut rng)?;
+                        (k.to_string(), categories[*k].clone())
                     }
                 };
-                gs.pick_name(&cat, &names).map(|n| (m.clone(), n, cat))
+                gs.pick_name(&cat, &names).map(|new_nick| Assignment {
+                    user_id: m.user.id,
+                    user_name: m.user.name.clone(),
+                    old_nick: m.nick.clone(),
+                    new_nick,
+                    category: cat,
+                })
             })
             .collect()
     };
 
-    // Persist the pool updates to DB (best-effort, outside the lock)
-    for (_, name, cat) in &assignments {
-        if let Err(e) = crate::db::add_used_name(&ctx.data().db, guild_id, cat, name).await {
-            tracing::warn!("DB error persisting used_name: {:?}", e);
+    // Persist the pool updates to DB in a single bulk insert (best-effort).
+    {
+        let pairs: Vec<(String, String)> = assignments
+            .iter()
+            .map(|a| (a.category.clone(), a.new_nick.clone()))
+            .collect();
+        if let Err(e) = crate::db::add_used_names_bulk(&ctx.data().db, guild_id, &pairs).await {
+            tracing::warn!("DB error bulk-persisting used_names: {:?}", e);
         }
     }
 
@@ -169,11 +199,13 @@ pub async fn randomize(
     tokio::spawn(async move {
         let mut changed = 0u32;
         let mut errors = 0u32;
+        let mut change_rows: Vec<crate::db::NickChangeRecord> = Vec::new();
+        let mut usage: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
 
-        for (member, new_nick, cat_name) in &assignments {
-            let nick = truncate_nick(new_nick);
+        for a in &assignments {
+            let nick = truncate_nick(&a.new_nick);
             match guild_id
-                .edit_member(&http, member.user.id, serenity::EditMember::new().nickname(nick))
+                .edit_member(&http, a.user_id, serenity::EditMember::new().nickname(nick))
                 .await
             {
                 Ok(_) => {
@@ -181,30 +213,26 @@ pub async fn randomize(
                     {
                         let mut data = bot_data.write_state().await;
                         data.guild_mut(guild_id).record_change(
-                            member.user.id.get(),
-                            member.user.name.clone(),
-                            member.nick.clone(),
-                            new_nick.clone(),
-                            cat_name.clone(),
+                            a.user_id.get(),
+                            a.user_name.clone(),
+                            a.old_nick.clone(),
+                            a.new_nick.clone(),
+                            a.category.clone(),
                         );
                     }
-                    // Persist this change (best-effort)
-                    let db = bot_data.db.clone();
-                    let gid = guild_id;
-                    let nn = new_nick.clone();
-                    let cn = cat_name.clone();
-                    let un = member.user.name.clone();
-                    let old = member.nick.clone();
-                    let uid = member.user.id.get();
-                    tokio::spawn(async move {
-                        let _ = crate::db::insert_nick_change(&db, gid, uid, &un, old.as_deref(), &nn, &cn).await;
-                        let _ = crate::db::increment_category_usage(&db, gid, &cn).await;
+                    *usage.entry(a.category.clone()).or_insert(0) += 1;
+                    change_rows.push(crate::db::NickChangeRecord {
+                        user_id: a.user_id.get(),
+                        user_name: a.user_name.clone(),
+                        old_nick: a.old_nick.clone(),
+                        new_nick: a.new_nick.clone(),
+                        category: a.category.clone(),
                     });
                 }
                 Err(e) => {
                     tracing::warn!(
                         "Could not change nick for {} in {}: {:?}",
-                        member.user.name,
+                        a.user_name,
                         guild_id,
                         e
                     );
@@ -212,6 +240,12 @@ pub async fn randomize(
                 }
             }
         }
+
+        // Persist all changes for this run in a few bulk round trips instead of
+        // a query (and a spawned task) per member.
+        let _ = crate::db::insert_nick_changes_bulk(&bot_data.db, guild_id, &change_rows).await;
+        let usage_list: Vec<(String, i64)> = usage.into_iter().collect();
+        let _ = crate::db::increment_category_usage_bulk(&bot_data.db, guild_id, &usage_list).await;
 
         // Increment the bulk-run counter, then persist the final aggregate
         // stats exactly once (this also fixes bulk_randomize_count never

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -155,7 +155,9 @@ pub async fn randomize(
             .iter()
             .filter(|m| !m.user.bot)
             .filter_map(|m| {
-                let (cat, names) = if let Some((c, n)) = &resolved { (c.clone(), n.clone()) } else {
+                let (cat, names) = if let Some((c, n)) = &resolved {
+                    (c.clone(), n.clone())
+                } else {
                     let k = chaos_keys.choose(&mut rng)?;
                     ((*k).clone(), categories[*k].clone())
                 };

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -1,8 +1,10 @@
+use std::time::Duration;
+
 use poise::serenity_prelude as serenity;
 
 use crate::{Context, Error};
 
-/// Assign a random nickname from a category to every member of the server.
+/// Assign a random nickname to every member of the server.
 ///
 /// Names are chosen without replacement — the full pool must be exhausted before
 /// any name is repeated.  Requires the **Manage Nicknames** permission.
@@ -15,40 +17,133 @@ use crate::{Context, Error};
 pub async fn randomize(
     ctx: Context<'_>,
     #[description = "Category to pick names from (omit for a random category)"]
+    #[autocomplete = "autocomplete_category"]
     category: Option<String>,
+    #[description = "Full chaos: give every member a name from a DIFFERENT random category"]
+    chaos: Option<bool>,
 ) -> Result<(), Error> {
     ctx.defer().await?;
 
     let guild_id = ctx.guild_id().unwrap();
     let http = ctx.serenity_context().http.clone();
+    let chaos = chaos.unwrap_or(false);
 
     // Collect members (up to 1,000 per page; paginated for larger servers)
     let members = fetch_all_members(guild_id, &http).await?;
+    let member_count = members.iter().filter(|m| !m.user.bot).count();
 
-    // Determine the category and its name list
-    let (cat_name, names) = {
+    if member_count == 0 {
+        ctx.say("There are no non-bot members to randomize.").await?;
+        return Ok(());
+    }
+
+    // Snapshot the category map once.
+    let categories = {
         let data = ctx.data().read_state().await;
-        let categories = match data.guild(guild_id) {
+        match data.guild(guild_id) {
             Some(gs) => gs.all_categories(),
             None => crate::data::builtin_categories(),
-        };
-        resolve_category(&categories, category.as_deref())?
+        }
     };
 
-    // Assign names (without-replacement draw, holding write lock briefly)
-    let assignments: Vec<(serenity::Member, String)> = {
+    // In chaos mode we draw a fresh category per member; otherwise resolve one.
+    let resolved = if chaos {
+        None
+    } else {
+        match resolve_category(&categories, category.as_deref()) {
+            Ok(pair) => Some(pair),
+            Err(e) => {
+                ctx.say(e.to_string()).await?;
+                return Ok(());
+            }
+        }
+    };
+
+    let scope_label = match &resolved {
+        Some((name, _)) => format!("the **{}** category", name),
+        None => "**random categories** (full chaos)".to_string(),
+    };
+
+    // ── Confirmation step ─────────────────────────────────────────────────────
+    let confirm_id = format!("cnn-confirm-{}", ctx.id());
+    let cancel_id = format!("cnn-cancel-{}", ctx.id());
+    let prompt = ctx
+        .send(
+            poise::CreateReply::default()
+                .content(format!(
+                    "⚠️ This will rename **{}** member(s) using {}.\nThis cannot be \
+                     automatically undone except via `/restore`. Proceed?",
+                    member_count, scope_label
+                ))
+                .components(vec![serenity::CreateActionRow::Buttons(vec![
+                    serenity::CreateButton::new(&confirm_id)
+                        .label("Randomize everyone")
+                        .style(serenity::ButtonStyle::Danger),
+                    serenity::CreateButton::new(&cancel_id)
+                        .label("Cancel")
+                        .style(serenity::ButtonStyle::Secondary),
+                ])]),
+        )
+        .await?;
+
+    let interaction = serenity::ComponentInteractionCollector::new(ctx)
+        .author_id(ctx.author().id)
+        .message_id(prompt.message().await?.id)
+        .timeout(Duration::from_secs(60))
+        .await;
+
+    let confirmed = match interaction {
+        Some(mci) if mci.data.custom_id == confirm_id => {
+            mci.create_response(ctx.serenity_context(), serenity::CreateInteractionResponse::Acknowledge)
+                .await?;
+            true
+        }
+        Some(mci) => {
+            mci.create_response(ctx.serenity_context(), serenity::CreateInteractionResponse::Acknowledge)
+                .await?;
+            false
+        }
+        None => false,
+    };
+
+    if !confirmed {
+        prompt
+            .edit(
+                ctx,
+                poise::CreateReply::default()
+                    .content("❌ Randomize cancelled.")
+                    .components(vec![]),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    // ── Assign names (without-replacement draw, holding write lock briefly) ────
+    // Each tuple is (member, new_nick, category_used).
+    let assignments: Vec<(serenity::Member, String, String)> = {
         let mut data = ctx.data().write_state().await;
         let gs = data.guild_mut(guild_id);
         members
             .iter()
             .filter(|m| !m.user.bot)
-            .filter_map(|m| gs.pick_name(&cat_name, &names).map(|n| (m.clone(), n)))
+            .filter_map(|m| {
+                let (cat, names) = match &resolved {
+                    Some((c, n)) => (c.clone(), n.clone()),
+                    None => {
+                        use rand::seq::IteratorRandom;
+                        let mut rng = rand::thread_rng();
+                        let (k, v) = categories.iter().choose(&mut rng)?;
+                        (k.clone(), v.clone())
+                    }
+                };
+                gs.pick_name(&cat, &names).map(|n| (m.clone(), n, cat))
+            })
             .collect()
     };
 
     // Persist the pool updates to DB (best-effort, outside the lock)
-    for (_, name) in &assignments {
-        if let Err(e) = crate::db::add_used_name(&ctx.data().db, guild_id, &cat_name, name).await {
+    for (_, name, cat) in &assignments {
+        if let Err(e) = crate::db::add_used_name(&ctx.data().db, guild_id, cat, name).await {
             tracing::warn!("DB error persisting used_name: {:?}", e);
         }
     }
@@ -57,13 +152,17 @@ pub async fn randomize(
     let channel_id = ctx.channel_id();
     let bot_data = ctx.data().clone();
 
-    // Acknowledge the interaction immediately so the 15-minute follow-up window
-    // is not at risk even for very large guilds.
-    ctx.say(format!(
-        "🎲 Randomizing **{}** member(s) from the **{}** category — this may take a moment…",
-        total, cat_name
-    ))
-    .await?;
+    prompt
+        .edit(
+            ctx,
+            poise::CreateReply::default()
+                .content(format!(
+                    "🎲 Randomizing **{}** member(s) using {} — this may take a moment…",
+                    total, scope_label
+                ))
+                .components(vec![]),
+        )
+        .await?;
 
     // Apply edits in the background; Serenity's built-in rate-limit handling
     // manages pacing automatically, removing the need for a fixed sleep.
@@ -71,7 +170,7 @@ pub async fn randomize(
         let mut changed = 0u32;
         let mut errors = 0u32;
 
-        for (member, new_nick) in &assignments {
+        for (member, new_nick, cat_name) in &assignments {
             let nick = truncate_nick(new_nick);
             match guild_id
                 .edit_member(&http, member.user.id, serenity::EditMember::new().nickname(nick))
@@ -79,7 +178,7 @@ pub async fn randomize(
             {
                 Ok(_) => {
                     changed += 1;
-                    let (total_ch, bulk_ct) = {
+                    {
                         let mut data = bot_data.write_state().await;
                         data.guild_mut(guild_id).record_change(
                             member.user.id.get(),
@@ -88,10 +187,8 @@ pub async fn randomize(
                             new_nick.clone(),
                             cat_name.clone(),
                         );
-                        let gs = data.guild(guild_id).unwrap();
-                        (gs.stats.total_changes, gs.stats.bulk_randomize_count)
-                    };
-                    // Persist to DB (best-effort)
+                    }
+                    // Persist this change (best-effort)
                     let db = bot_data.db.clone();
                     let gid = guild_id;
                     let nn = new_nick.clone();
@@ -101,7 +198,6 @@ pub async fn randomize(
                     let uid = member.user.id.get();
                     tokio::spawn(async move {
                         let _ = crate::db::insert_nick_change(&db, gid, uid, &un, old.as_deref(), &nn, &cn).await;
-                        let _ = crate::db::upsert_guild_stats(&db, gid, total_ch, bulk_ct).await;
                         let _ = crate::db::increment_category_usage(&db, gid, &cn).await;
                     });
                 }
@@ -117,12 +213,17 @@ pub async fn randomize(
             }
         }
 
-        {
+        // Increment the bulk-run counter, then persist the final aggregate
+        // stats exactly once (this also fixes bulk_randomize_count never
+        // reaching the database).
+        let (total_ch, bulk_ct) = {
             let mut data = bot_data.write_state().await;
-            data.guild_mut(guild_id).stats.bulk_randomize_count += 1;
-        }
+            let gs = data.guild_mut(guild_id);
+            gs.stats.bulk_randomize_count += 1;
+            (gs.stats.total_changes, gs.stats.bulk_randomize_count)
+        };
+        let _ = crate::db::upsert_guild_stats(&bot_data.db, guild_id, total_ch, bulk_ct).await;
 
-        // Send a follow-up message with the final tally.
         tracing::info!(
             guild = %guild_id,
             changed,
@@ -134,7 +235,12 @@ pub async fn randomize(
             changed, errors
         );
         if let Err(e) = channel_id
-            .send_message(&http, serenity::CreateMessage::new().content(summary))
+            .send_message(
+                &http,
+                serenity::CreateMessage::new()
+                    .content(summary)
+                    .allowed_mentions(serenity::CreateAllowedMentions::new()),
+            )
             .await
         {
             tracing::warn!("Failed to send randomize summary to channel {}: {:?}", channel_id, e);
@@ -213,6 +319,40 @@ pub fn escape_mentions(s: &str) -> String {
     s.replace('@', "@\u{200b}")
 }
 
+/// Friendly, actionable message shown when the bot cannot edit a member's
+/// nickname (almost always role hierarchy / ownership / missing permission).
+pub fn nick_edit_failure_message(user_name: &str) -> String {
+    format!(
+        "❌ Couldn't change **{}**'s nickname. This usually means they have a \
+         role higher than mine, they're the server owner, or I'm missing the \
+         **Manage Nicknames** permission.",
+        escape_mentions(user_name)
+    )
+}
+
+/// Autocomplete handler for the `category` option of several commands.
+/// Includes this guild's custom categories alongside the built-ins.
+pub async fn autocomplete_category(
+    ctx: Context<'_>,
+    partial: &str,
+) -> impl Iterator<Item = String> {
+    let partial = partial.to_lowercase();
+    let mut names: Vec<String> = if let Some(gid) = ctx.guild_id() {
+        let data = ctx.data().read_state().await;
+        match data.guild(gid) {
+            Some(gs) => gs.all_categories().into_keys().collect(),
+            None => crate::data::builtin_category_names(),
+        }
+    } else {
+        crate::data::builtin_category_names()
+    };
+    names.sort();
+    names
+        .into_iter()
+        .filter(move |c| c.starts_with(&partial))
+        .take(25)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,6 +386,12 @@ mod tests {
         assert_eq!(result.chars().count(), 32);
     }
 
+    #[test]
+    fn truncate_nick_one_over_limit() {
+        let s = "x".repeat(33);
+        assert_eq!(truncate_nick(&s).chars().count(), 32);
+    }
+
     // ── escape_mentions ───────────────────────────────────────────────────────
 
     #[test]
@@ -265,6 +411,27 @@ mod tests {
     fn escape_mentions_multiple_at_signs() {
         let result = escape_mentions("@a @b");
         assert_eq!(result.matches('\u{200b}').count(), 2);
+    }
+
+    #[test]
+    fn escape_mentions_neutralizes_here() {
+        // @here must not survive intact as a working ping.
+        assert!(!escape_mentions("@here").contains("@h"));
+    }
+
+    // ── nick_edit_failure_message ─────────────────────────────────────────────
+
+    #[test]
+    fn failure_message_mentions_user_and_guidance() {
+        let m = nick_edit_failure_message("Alice");
+        assert!(m.contains("Alice"));
+        assert!(m.contains("Manage Nicknames"));
+    }
+
+    #[test]
+    fn failure_message_escapes_at_in_username() {
+        let m = nick_edit_failure_message("@everyone");
+        assert!(m.contains('\u{200b}'));
     }
 
     // ── resolve_category ──────────────────────────────────────────────────────
@@ -291,10 +458,25 @@ mod tests {
     }
 
     #[test]
+    fn resolve_category_is_case_insensitive() {
+        let cats = sample_categories();
+        let (name, _) = resolve_category(&cats, Some("SCIENTISTS")).unwrap();
+        assert_eq!(name, "scientists");
+    }
+
+    #[test]
     fn resolve_category_unknown_name_returns_error() {
         let cats = sample_categories();
         let result = resolve_category(&cats, Some("dinosaurs"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_category_unknown_name_lists_available() {
+        let cats = sample_categories();
+        let err = resolve_category(&cats, Some("nope")).unwrap_err().to_string();
+        assert!(err.contains("scientists"));
+        assert!(err.contains("planets"));
     }
 
     #[test]

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -21,7 +21,7 @@ pub async fn reset_pool(
 ) -> Result<(), Error> {
     let guild_id = ctx.guild_id().unwrap();
     // Normalise to lowercase so it matches the stored keys
-    let cat = category.as_deref().map(|s| s.to_lowercase());
+    let cat = category.as_deref().map(str::to_lowercase);
 
     // Reject typos instead of silently reporting a successful reset.
     if let Some(c) = &cat {
@@ -33,7 +33,7 @@ pub async fn reset_pool(
             }
         };
         if !known {
-            ctx.say(format!("❌ No category named `{}` exists.", c))
+            ctx.say(format!("❌ No category named `{c}` exists."))
                 .await?;
             return Ok(());
         }
@@ -57,7 +57,7 @@ pub async fn reset_pool(
 
     match &cat {
         Some(c) => {
-            ctx.say(format!("🔄 Reset name pool for category **{}**.", c))
+            ctx.say(format!("🔄 Reset name pool for category **{c}**."))
                 .await?
         }
         None => {

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -33,7 +33,8 @@ pub async fn reset_pool(
             }
         };
         if !known {
-            ctx.say(format!("❌ No category named `{}` exists.", c)).await?;
+            ctx.say(format!("❌ No category named `{}` exists.", c))
+                .await?;
             return Ok(());
         }
     }
@@ -59,7 +60,10 @@ pub async fn reset_pool(
             ctx.say(format!("🔄 Reset name pool for category **{}**.", c))
                 .await?
         }
-        None => ctx.say("🔄 Reset name pools for **all** categories.").await?,
+        None => {
+            ctx.say("🔄 Reset name pools for **all** categories.")
+                .await?
+        }
     };
 
     Ok(())

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -15,11 +15,28 @@ use crate::{Context, Error};
 )]
 pub async fn reset_pool(
     ctx: Context<'_>,
-    #[description = "Category to reset (omit to reset all categories)"] category: Option<String>,
+    #[description = "Category to reset (omit to reset all categories)"]
+    #[autocomplete = "crate::commands::randomize::autocomplete_category"]
+    category: Option<String>,
 ) -> Result<(), Error> {
     let guild_id = ctx.guild_id().unwrap();
     // Normalise to lowercase so it matches the stored keys
     let cat = category.as_deref().map(|s| s.to_lowercase());
+
+    // Reject typos instead of silently reporting a successful reset.
+    if let Some(c) = &cat {
+        let known = {
+            let data = ctx.data().read_state().await;
+            match data.guild(guild_id) {
+                Some(gs) => gs.all_categories().contains_key(c),
+                None => crate::data::builtin_category_names().contains(c),
+            }
+        };
+        if !known {
+            ctx.say(format!("❌ No category named `{}` exists.", c)).await?;
+            return Ok(());
+        }
+    }
 
     {
         let mut data = ctx.data().write_state().await;

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,0 +1,88 @@
+use poise::serenity_prelude as serenity;
+
+use crate::commands::randomize::truncate_nick;
+use crate::{Context, Error};
+
+/// Restore members' pre-bot nicknames (the undo for `/randomize`).
+///
+/// Pass a `user` to restore just that person; omit it to restore everyone the
+/// bot has ever renamed in this server, using recorded history.
+/// Requires the **Manage Nicknames** permission.
+#[poise::command(
+    slash_command,
+    guild_only,
+    required_permissions = "MANAGE_NICKNAMES",
+    description_localized("en-US", "Restore members' original (pre-bot) nicknames")
+)]
+pub async fn restore(
+    ctx: Context<'_>,
+    #[description = "Restore only this user (omit to restore everyone)"]
+    user: Option<serenity::User>,
+) -> Result<(), Error> {
+    ctx.defer().await?;
+
+    let guild_id = ctx.guild_id().unwrap();
+    let http = ctx.serenity_context().http.clone();
+
+    let targets = crate::db::original_nicks(&ctx.data().db, guild_id, user.as_ref().map(|u| u.id.get()))
+        .await?;
+
+    if targets.is_empty() {
+        ctx.say("Nothing to restore — no recorded nickname history for that selection.")
+            .await?;
+        return Ok(());
+    }
+
+    let total = targets.len();
+    let channel_id = ctx.channel_id();
+
+    ctx.say(format!(
+        "↩️ Restoring original nickname(s) for **{}** member(s) — this may take a moment…",
+        total
+    ))
+    .await?;
+
+    tokio::spawn(async move {
+        let mut restored = 0u32;
+        let mut errors = 0u32;
+
+        for (uid, old_nick) in &targets {
+            // An empty string tells Discord to clear the nickname, which is the
+            // correct behaviour when the user had none before the bot acted.
+            let target = old_nick.as_deref().map(truncate_nick).unwrap_or("");
+            match guild_id
+                .edit_member(
+                    &http,
+                    serenity::UserId::new(*uid),
+                    serenity::EditMember::new().nickname(target),
+                )
+                .await
+            {
+                Ok(_) => restored += 1,
+                Err(e) => {
+                    tracing::warn!("Could not restore nick for {} in {}: {:?}", uid, guild_id, e);
+                    errors += 1;
+                }
+            }
+        }
+
+        tracing::info!(guild = %guild_id, restored, errors, "Background restore task completed");
+        let summary = format!(
+            "✅ Restore complete! Restored: **{}** | ❌ Skipped/errors: **{}**",
+            restored, errors
+        );
+        if let Err(e) = channel_id
+            .send_message(
+                &http,
+                serenity::CreateMessage::new()
+                    .content(summary)
+                    .allowed_mentions(serenity::CreateAllowedMentions::new()),
+            )
+            .await
+        {
+            tracing::warn!("Failed to send restore summary to channel {}: {:?}", channel_id, e);
+        }
+    });
+
+    Ok(())
+}

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -16,16 +16,18 @@ use crate::{Context, Error};
 )]
 pub async fn restore(
     ctx: Context<'_>,
-    #[description = "Restore only this user (omit to restore everyone)"]
-    user: Option<serenity::User>,
+    #[description = "Restore only this user (omit to restore everyone)"] user: Option<
+        serenity::User,
+    >,
 ) -> Result<(), Error> {
     ctx.defer().await?;
 
     let guild_id = ctx.guild_id().unwrap();
     let http = ctx.serenity_context().http.clone();
 
-    let targets = crate::db::original_nicks(&ctx.data().db, guild_id, user.as_ref().map(|u| u.id.get()))
-        .await?;
+    let targets =
+        crate::db::original_nicks(&ctx.data().db, guild_id, user.as_ref().map(|u| u.id.get()))
+            .await?;
 
     if targets.is_empty() {
         ctx.say("Nothing to restore — no recorded nickname history for that selection.")
@@ -60,7 +62,12 @@ pub async fn restore(
             {
                 Ok(_) => restored += 1,
                 Err(e) => {
-                    tracing::warn!("Could not restore nick for {} in {}: {:?}", uid, guild_id, e);
+                    tracing::warn!(
+                        "Could not restore nick for {} in {}: {:?}",
+                        uid,
+                        guild_id,
+                        e
+                    );
                     errors += 1;
                 }
             }
@@ -80,7 +87,11 @@ pub async fn restore(
             )
             .await
         {
-            tracing::warn!("Failed to send restore summary to channel {}: {:?}", channel_id, e);
+            tracing::warn!(
+                "Failed to send restore summary to channel {}: {:?}",
+                channel_id,
+                e
+            );
         }
     });
 

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -39,8 +39,7 @@ pub async fn restore(
     let channel_id = ctx.channel_id();
 
     ctx.say(format!(
-        "↩️ Restoring original nickname(s) for **{}** member(s) — this may take a moment…",
-        total
+        "↩️ Restoring original nickname(s) for **{total}** member(s) — this may take a moment…"
     ))
     .await?;
 
@@ -51,7 +50,7 @@ pub async fn restore(
         for (uid, old_nick) in &targets {
             // An empty string tells Discord to clear the nickname, which is the
             // correct behaviour when the user had none before the bot acted.
-            let target = old_nick.as_deref().map(truncate_nick).unwrap_or("");
+            let target = old_nick.as_deref().map_or("", truncate_nick);
             match guild_id
                 .edit_member(
                     &http,
@@ -75,8 +74,7 @@ pub async fn restore(
 
         tracing::info!(guild = %guild_id, restored, errors, "Background restore task completed");
         let summary = format!(
-            "✅ Restore complete! Restored: **{}** | ❌ Skipped/errors: **{}**",
-            restored, errors
+            "✅ Restore complete! Restored: **{restored}** | ❌ Skipped/errors: **{errors}**"
         );
         if let Err(e) = channel_id
             .send_message(

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -24,7 +24,7 @@ pub async fn stats(ctx: Context<'_>) -> Result<(), Error> {
                     .iter()
                     .map(|(k, v)| (k.clone(), *v))
                     .collect();
-                cats.sort_by(|a, b| b.1.cmp(&a.1));
+                cats.sort_by_key(|x| std::cmp::Reverse(x.1));
                 (gs.stats.total_changes, gs.stats.bulk_randomize_count, cats)
             }
         }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,138 +1,26 @@
 use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// Built-in name categories, embedded from `categories.json` at compile time.
+/// Parsing happens once and the result is cached for the lifetime of the process.
+const CATEGORIES_JSON: &str = include_str!("categories.json");
+
+fn categories() -> &'static HashMap<String, Vec<String>> {
+    static CACHE: OnceLock<HashMap<String, Vec<String>>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        serde_json::from_str(CATEGORIES_JSON)
+            .expect("src/categories.json must be valid JSON of {category: [names]}")
+    })
+}
 
 /// Return a fresh copy of the built-in name categories.
 pub fn builtin_categories() -> HashMap<String, Vec<String>> {
-    let raw: &[(&str, &[&str])] = &[
-        (
-            "scientists",
-            &[
-                "Einstein", "Newton", "Darwin", "Curie", "Tesla", "Feynman", "Hawking", "Bohr",
-                "Faraday", "Turing", "Heisenberg", "Schrodinger", "Planck", "Dirac", "Fermi",
-                "Oppenheimer", "Lovelace", "Noether", "Ramanujan", "Euler",
-            ],
-        ),
-        (
-            "elements",
-            &[
-                "Hydrogen", "Helium", "Lithium", "Carbon", "Nitrogen", "Oxygen", "Neon",
-                "Sodium", "Magnesium", "Aluminum", "Silicon", "Phosphorus", "Sulfur", "Chlorine",
-                "Argon", "Potassium", "Calcium", "Iron", "Copper", "Zinc", "Silver", "Gold",
-                "Mercury", "Lead", "Uranium",
-            ],
-        ),
-        (
-            "chemical_compounds",
-            &[
-                "Caffeine", "Aspirin", "Serotonin", "Dopamine", "Adrenaline", "Glucose",
-                "Ethanol", "Acetone", "Benzene", "Toluene", "Acetylene", "Propane", "Methane",
-                "Ozone", "Ammonia", "Sucrose", "Fructose", "Lactose", "Galactose", "Maltose",
-            ],
-        ),
-        (
-            "amusement_parks",
-            &[
-                "Disneyland",
-                "Six Flags",
-                "Cedar Point",
-                "Universal Studios",
-                "Busch Gardens",
-                "Knott's Berry Farm",
-                "Hersheypark",
-                "SeaWorld",
-                "Dollywood",
-                "Alton Towers",
-                "Europa Park",
-                "PortAventura",
-                "Thorpe Park",
-                "Legoland",
-                "Dreamworld",
-                "Tivoli Gardens",
-                "Phantasialand",
-                "Holiday World",
-                "Carowinds",
-                "Adventureland",
-            ],
-        ),
-        (
-            "dinosaurs",
-            &[
-                "T-Rex",
-                "Velociraptor",
-                "Triceratops",
-                "Stegosaurus",
-                "Brachiosaurus",
-                "Ankylosaurus",
-                "Pterodactyl",
-                "Diplodocus",
-                "Allosaurus",
-                "Spinosaurus",
-                "Iguanodon",
-                "Pachycephalosaurus",
-                "Parasaurolophus",
-                "Gallimimus",
-                "Carnotaurus",
-                "Dilophosaurus",
-                "Ceratosaurus",
-                "Compsognathus",
-                "Maiasaura",
-                "Oviraptor",
-            ],
-        ),
-        (
-            "planets",
-            &[
-                "Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune",
-                "Pluto", "Ceres", "Eris", "Makemake", "Haumea", "Sedna", "Quaoar",
-            ],
-        ),
-        (
-            "colors",
-            &[
-                "Crimson", "Scarlet", "Vermilion", "Tangerine", "Amber", "Chartreuse",
-                "Viridian", "Cerulean", "Cobalt", "Indigo", "Violet", "Magenta", "Fuchsia",
-                "Turquoise", "Periwinkle", "Sienna", "Ochre", "Umber", "Sepia", "Ecru",
-            ],
-        ),
-        (
-            "fruits",
-            &[
-                "Mango",
-                "Papaya",
-                "Persimmon",
-                "Pomegranate",
-                "Lychee",
-                "Dragonfruit",
-                "Starfruit",
-                "Jackfruit",
-                "Durian",
-                "Guava",
-                "Passion Fruit",
-                "Tamarind",
-                "Kumquat",
-                "Rambutan",
-                "Soursop",
-                "Ackee",
-                "Feijoa",
-                "Cherimoya",
-                "Langsat",
-                "Salak",
-            ],
-        ),
-    ];
-
-    raw.iter()
-        .map(|(cat, names)| {
-            (
-                cat.to_string(),
-                names.iter().map(|n| n.to_string()).collect(),
-            )
-        })
-        .collect()
+    categories().clone()
 }
 
 /// Built-in category names as a sorted list (for display).
 pub fn builtin_category_names() -> Vec<String> {
-    let mut names: Vec<String> = builtin_categories().into_keys().collect();
+    let mut names: Vec<String> = categories().keys().cloned().collect();
     names.sort();
     names
 }
@@ -178,5 +66,54 @@ mod tests {
         for expected in &["scientists", "elements", "planets", "colors"] {
             assert!(cats.contains_key(*expected), "missing category '{}'", expected);
         }
+    }
+
+    // ── categories.json integrity ─────────────────────────────────────────────
+
+    #[test]
+    fn embedded_json_parses() {
+        // Panics with a clear message if categories.json is malformed.
+        let _ = categories();
+    }
+
+    #[test]
+    fn no_name_has_leading_or_trailing_whitespace() {
+        for (cat, names) in builtin_categories() {
+            for n in &names {
+                assert_eq!(n.trim(), n, "name '{}' in '{}' has surrounding whitespace", n, cat);
+                assert!(!n.is_empty(), "empty name in category '{}'", cat);
+            }
+        }
+    }
+
+    #[test]
+    fn no_duplicate_names_within_a_category() {
+        for (cat, names) in builtin_categories() {
+            let mut seen = std::collections::HashSet::new();
+            for n in &names {
+                assert!(seen.insert(n.clone()), "duplicate '{}' in category '{}'", n, cat);
+            }
+        }
+    }
+
+    #[test]
+    fn every_name_fits_discord_nick_limit() {
+        for (cat, names) in builtin_categories() {
+            for n in &names {
+                assert!(
+                    n.chars().count() <= 32,
+                    "name '{}' in '{}' exceeds Discord's 32-char nickname limit",
+                    n,
+                    cat
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cache_returns_stable_reference() {
+        let a = categories() as *const _;
+        let b = categories() as *const _;
+        assert_eq!(a, b, "categories() should cache and return the same instance");
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -64,7 +64,11 @@ mod tests {
     fn known_categories_are_present() {
         let cats = builtin_categories();
         for expected in &["scientists", "elements", "planets", "colors"] {
-            assert!(cats.contains_key(*expected), "missing category '{}'", expected);
+            assert!(
+                cats.contains_key(*expected),
+                "missing category '{}'",
+                expected
+            );
         }
     }
 
@@ -80,7 +84,13 @@ mod tests {
     fn no_name_has_leading_or_trailing_whitespace() {
         for (cat, names) in builtin_categories() {
             for n in &names {
-                assert_eq!(n.trim(), n, "name '{}' in '{}' has surrounding whitespace", n, cat);
+                assert_eq!(
+                    n.trim(),
+                    n,
+                    "name '{}' in '{}' has surrounding whitespace",
+                    n,
+                    cat
+                );
                 assert!(!n.is_empty(), "empty name in category '{}'", cat);
             }
         }
@@ -91,7 +101,12 @@ mod tests {
         for (cat, names) in builtin_categories() {
             let mut seen = std::collections::HashSet::new();
             for n in &names {
-                assert!(seen.insert(n.clone()), "duplicate '{}' in category '{}'", n, cat);
+                assert!(
+                    seen.insert(n.clone()),
+                    "duplicate '{}' in category '{}'",
+                    n,
+                    cat
+                );
             }
         }
     }
@@ -114,6 +129,9 @@ mod tests {
     fn cache_returns_stable_reference() {
         let a = categories() as *const _;
         let b = categories() as *const _;
-        assert_eq!(a, b, "categories() should cache and return the same instance");
+        assert_eq!(
+            a, b,
+            "categories() should cache and return the same instance"
+        );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -249,6 +249,52 @@ pub async fn clear_used_names(
     Ok(())
 }
 
+/// Return each user's *original* nickname for this guild — the `old_nick`
+/// recorded on the earliest nick-change row for that user. `None` means the
+/// user had no nickname before the bot first touched them (so restoring
+/// should clear their nickname). Used by `/restore`.
+pub async fn original_nicks(
+    pool: &PgPool,
+    guild_id: GuildId,
+    user_id: Option<u64>,
+) -> Result<Vec<(u64, Option<String>)>, sqlx::Error> {
+    let gid = guild_id.get() as i64;
+    let rows = match user_id {
+        Some(uid) => {
+            sqlx::query(
+                r#"
+                SELECT DISTINCT ON (user_id) user_id, old_nick
+                FROM nick_changes
+                WHERE guild_id = $1 AND user_id = $2
+                ORDER BY user_id, changed_at ASC
+                "#,
+            )
+            .bind(gid)
+            .bind(uid as i64)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query(
+                r#"
+                SELECT DISTINCT ON (user_id) user_id, old_nick
+                FROM nick_changes
+                WHERE guild_id = $1
+                ORDER BY user_id, changed_at ASC
+                "#,
+            )
+            .bind(gid)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.get::<i64, _>("user_id") as u64, r.get::<Option<String>, _>("old_nick")))
+        .collect())
+}
+
 /// Insert a single nick-change row.
 pub async fn insert_nick_change(
     pool: &PgPool,

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,7 +26,7 @@ pub async fn setup(database_url: &str) -> Result<PgPool, sqlx::Error> {
 /// Load all guild states that exist in the database.
 pub async fn load_all_guilds(pool: &PgPool) -> Result<Vec<(GuildId, GuildState)>, sqlx::Error> {
     let guild_ids: Vec<i64> = sqlx::query_scalar(
-        r#"
+        r"
         SELECT DISTINCT guild_id FROM (
             SELECT guild_id FROM guild_stats
             UNION
@@ -36,7 +36,7 @@ pub async fn load_all_guilds(pool: &PgPool) -> Result<Vec<(GuildId, GuildState)>
             UNION
             SELECT guild_id FROM nick_changes
         ) AS g
-        "#,
+        ",
     )
     .fetch_all(pool)
     .await?;
@@ -81,13 +81,13 @@ async fn load_guild(pool: &PgPool, guild_id: GuildId) -> Result<GuildState, sqlx
 
     // History (latest 200)
     let hist_rows = sqlx::query(
-        r#"
+        r"
         SELECT user_id, user_name, old_nick, new_nick, category, changed_at
         FROM nick_changes
         WHERE guild_id = $1
         ORDER BY changed_at DESC
         LIMIT 200
-        "#,
+        ",
     )
     .bind(gid)
     .fetch_all(pool)
@@ -144,8 +144,8 @@ async fn load_guild(pool: &PgPool, guild_id: GuildId) -> Result<GuildState, sqlx
         history,
         stats: GuildStats {
             total_changes,
-            bulk_randomize_count,
             category_usage,
+            bulk_randomize_count,
         },
     })
 }
@@ -161,11 +161,11 @@ pub async fn upsert_custom_category(
 ) -> Result<(), sqlx::Error> {
     let gid = guild_id.get() as i64;
     sqlx::query(
-        r#"
+        r"
         INSERT INTO custom_categories (guild_id, name, items)
         VALUES ($1, $2, $3)
         ON CONFLICT (guild_id, name) DO UPDATE SET items = EXCLUDED.items
-        "#,
+        ",
     )
     .bind(gid)
     .bind(name)
@@ -199,11 +199,11 @@ pub async fn add_used_name(
 ) -> Result<(), sqlx::Error> {
     let gid = guild_id.get() as i64;
     sqlx::query(
-        r#"
+        r"
         INSERT INTO used_names (guild_id, category_name, name)
         VALUES ($1, $2, $3)
         ON CONFLICT DO NOTHING
-        "#,
+        ",
     )
     .bind(gid)
     .bind(category)
@@ -226,11 +226,11 @@ pub async fn add_used_names_bulk(
     let cats: Vec<String> = pairs.iter().map(|(c, _)| c.clone()).collect();
     let names: Vec<String> = pairs.iter().map(|(_, n)| n.clone()).collect();
     sqlx::query(
-        r#"
+        r"
         INSERT INTO used_names (guild_id, category_name, name)
         SELECT $1, c, n FROM UNNEST($2::text[], $3::text[]) AS t(c, n)
         ON CONFLICT DO NOTHING
-        "#,
+        ",
     )
     .bind(gid)
     .bind(&cats)
@@ -265,12 +265,12 @@ pub async fn insert_nick_changes_bulk(
     let news: Vec<String> = rows.iter().map(|r| r.new_nick.clone()).collect();
     let cats: Vec<String> = rows.iter().map(|r| r.category.clone()).collect();
     sqlx::query(
-        r#"
+        r"
         INSERT INTO nick_changes (guild_id, user_id, user_name, old_nick, new_nick, category)
         SELECT $1, uid, un, old, nn, cat
         FROM UNNEST($2::bigint[], $3::text[], $4::text[], $5::text[], $6::text[])
             AS t(uid, un, old, nn, cat)
-        "#,
+        ",
     )
     .bind(gid)
     .bind(&uids)
@@ -296,12 +296,12 @@ pub async fn increment_category_usage_bulk(
     let cats: Vec<String> = counts.iter().map(|(c, _)| c.clone()).collect();
     let deltas: Vec<i64> = counts.iter().map(|(_, n)| *n).collect();
     sqlx::query(
-        r#"
+        r"
         INSERT INTO category_usage (guild_id, category_name, usage_count)
         SELECT $1, c, n FROM UNNEST($2::text[], $3::bigint[]) AS t(c, n)
         ON CONFLICT (guild_id, category_name) DO UPDATE
             SET usage_count = category_usage.usage_count + EXCLUDED.usage_count
-        "#,
+        ",
     )
     .bind(gid)
     .bind(&cats)
@@ -349,12 +349,12 @@ pub async fn original_nicks(
     let rows = match user_id {
         Some(uid) => {
             sqlx::query(
-                r#"
+                r"
                 SELECT DISTINCT ON (user_id) user_id, old_nick
                 FROM nick_changes
                 WHERE guild_id = $1 AND user_id = $2
                 ORDER BY user_id, changed_at ASC
-                "#,
+                ",
             )
             .bind(gid)
             .bind(uid as i64)
@@ -363,12 +363,12 @@ pub async fn original_nicks(
         }
         None => {
             sqlx::query(
-                r#"
+                r"
                 SELECT DISTINCT ON (user_id) user_id, old_nick
                 FROM nick_changes
                 WHERE guild_id = $1
                 ORDER BY user_id, changed_at ASC
-                "#,
+                ",
             )
             .bind(gid)
             .fetch_all(pool)
@@ -400,10 +400,10 @@ pub async fn insert_nick_change(
     let gid = guild_id.get() as i64;
     let uid = user_id as i64;
     sqlx::query(
-        r#"
+        r"
         INSERT INTO nick_changes (guild_id, user_id, user_name, old_nick, new_nick, category)
         VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
+        ",
     )
     .bind(gid)
     .bind(uid)
@@ -425,13 +425,13 @@ pub async fn upsert_guild_stats(
 ) -> Result<(), sqlx::Error> {
     let gid = guild_id.get() as i64;
     sqlx::query(
-        r#"
+        r"
         INSERT INTO guild_stats (guild_id, total_changes, bulk_randomize_count)
         VALUES ($1, $2, $3)
         ON CONFLICT (guild_id) DO UPDATE
             SET total_changes        = EXCLUDED.total_changes,
                 bulk_randomize_count = EXCLUDED.bulk_randomize_count
-        "#,
+        ",
     )
     .bind(gid)
     .bind(total_changes as i64)
@@ -449,12 +449,12 @@ pub async fn increment_category_usage(
 ) -> Result<(), sqlx::Error> {
     let gid = guild_id.get() as i64;
     sqlx::query(
-        r#"
+        r"
         INSERT INTO category_usage (guild_id, category_name, usage_count)
         VALUES ($1, $2, 1)
         ON CONFLICT (guild_id, category_name) DO UPDATE
             SET usage_count = category_usage.usage_count + 1
-        "#,
+        ",
     )
     .bind(gid)
     .bind(category)

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use poise::serenity_prelude::GuildId;
-use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use sqlx::{postgres::PgPoolOptions, PgPool, Row};
 
 use crate::state::{GuildState, GuildStats, HistoryEntry};
 
@@ -24,9 +24,7 @@ pub async fn setup(database_url: &str) -> Result<PgPool, sqlx::Error> {
 // ── Startup load ─────────────────────────────────────────────────────────────
 
 /// Load all guild states that exist in the database.
-pub async fn load_all_guilds(
-    pool: &PgPool,
-) -> Result<Vec<(GuildId, GuildState)>, sqlx::Error> {
+pub async fn load_all_guilds(pool: &PgPool) -> Result<Vec<(GuildId, GuildState)>, sqlx::Error> {
     let guild_ids: Vec<i64> = sqlx::query_scalar(
         r#"
         SELECT DISTINCT guild_id FROM (
@@ -56,12 +54,10 @@ async fn load_guild(pool: &PgPool, guild_id: GuildId) -> Result<GuildState, sqlx
     let gid = guild_id.get() as i64;
 
     // Custom categories
-    let cat_rows = sqlx::query(
-        "SELECT name, items FROM custom_categories WHERE guild_id = $1",
-    )
-    .bind(gid)
-    .fetch_all(pool)
-    .await?;
+    let cat_rows = sqlx::query("SELECT name, items FROM custom_categories WHERE guild_id = $1")
+        .bind(gid)
+        .fetch_all(pool)
+        .await?;
 
     let mut custom_categories: HashMap<String, Vec<String>> = HashMap::new();
     for row in cat_rows {
@@ -71,12 +67,10 @@ async fn load_guild(pool: &PgPool, guild_id: GuildId) -> Result<GuildState, sqlx
     }
 
     // Used names
-    let used_rows = sqlx::query(
-        "SELECT category_name, name FROM used_names WHERE guild_id = $1",
-    )
-    .bind(gid)
-    .fetch_all(pool)
-    .await?;
+    let used_rows = sqlx::query("SELECT category_name, name FROM used_names WHERE guild_id = $1")
+        .bind(gid)
+        .fetch_all(pool)
+        .await?;
 
     let mut used_names: HashMap<String, HashSet<String>> = HashMap::new();
     for row in used_rows {
@@ -131,12 +125,11 @@ async fn load_guild(pool: &PgPool, guild_id: GuildId) -> Result<GuildState, sqlx
     };
 
     // Category usage
-    let usage_rows = sqlx::query(
-        "SELECT category_name, usage_count FROM category_usage WHERE guild_id = $1",
-    )
-    .bind(gid)
-    .fetch_all(pool)
-    .await?;
+    let usage_rows =
+        sqlx::query("SELECT category_name, usage_count FROM category_usage WHERE guild_id = $1")
+            .bind(gid)
+            .fetch_all(pool)
+            .await?;
 
     let mut category_usage: HashMap<String, u64> = HashMap::new();
     for row in usage_rows {
@@ -189,13 +182,11 @@ pub async fn delete_custom_category(
     name: &str,
 ) -> Result<(), sqlx::Error> {
     let gid = guild_id.get() as i64;
-    sqlx::query(
-        "DELETE FROM custom_categories WHERE guild_id = $1 AND name = $2",
-    )
-    .bind(gid)
-    .bind(name)
-    .execute(pool)
-    .await?;
+    sqlx::query("DELETE FROM custom_categories WHERE guild_id = $1 AND name = $2")
+        .bind(gid)
+        .bind(name)
+        .execute(pool)
+        .await?;
     Ok(())
 }
 
@@ -329,13 +320,11 @@ pub async fn clear_used_names(
     let gid = guild_id.get() as i64;
     match category {
         Some(cat) => {
-            sqlx::query(
-                "DELETE FROM used_names WHERE guild_id = $1 AND category_name = $2",
-            )
-            .bind(gid)
-            .bind(cat)
-            .execute(pool)
-            .await?;
+            sqlx::query("DELETE FROM used_names WHERE guild_id = $1 AND category_name = $2")
+                .bind(gid)
+                .bind(cat)
+                .execute(pool)
+                .await?;
         }
         None => {
             sqlx::query("DELETE FROM used_names WHERE guild_id = $1")
@@ -389,7 +378,12 @@ pub async fn original_nicks(
 
     Ok(rows
         .into_iter()
-        .map(|r| (r.get::<i64, _>("user_id") as u64, r.get::<Option<String>, _>("old_nick")))
+        .map(|r| {
+            (
+                r.get::<i64, _>("user_id") as u64,
+                r.get::<Option<String>, _>("old_nick"),
+            )
+        })
         .collect())
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -222,6 +222,104 @@ pub async fn add_used_name(
     Ok(())
 }
 
+/// Bulk-mark many `(category, name)` pairs as used in a single round trip.
+pub async fn add_used_names_bulk(
+    pool: &PgPool,
+    guild_id: GuildId,
+    pairs: &[(String, String)],
+) -> Result<(), sqlx::Error> {
+    if pairs.is_empty() {
+        return Ok(());
+    }
+    let gid = guild_id.get() as i64;
+    let cats: Vec<String> = pairs.iter().map(|(c, _)| c.clone()).collect();
+    let names: Vec<String> = pairs.iter().map(|(_, n)| n.clone()).collect();
+    sqlx::query(
+        r#"
+        INSERT INTO used_names (guild_id, category_name, name)
+        SELECT $1, c, n FROM UNNEST($2::text[], $3::text[]) AS t(c, n)
+        ON CONFLICT DO NOTHING
+        "#,
+    )
+    .bind(gid)
+    .bind(&cats)
+    .bind(&names)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// One recorded nickname change, used for bulk persistence.
+pub struct NickChangeRecord {
+    pub user_id: u64,
+    pub user_name: String,
+    pub old_nick: Option<String>,
+    pub new_nick: String,
+    pub category: String,
+}
+
+/// Bulk-insert many nick-change rows in a single round trip.
+pub async fn insert_nick_changes_bulk(
+    pool: &PgPool,
+    guild_id: GuildId,
+    rows: &[NickChangeRecord],
+) -> Result<(), sqlx::Error> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let gid = guild_id.get() as i64;
+    let uids: Vec<i64> = rows.iter().map(|r| r.user_id as i64).collect();
+    let unames: Vec<String> = rows.iter().map(|r| r.user_name.clone()).collect();
+    let olds: Vec<Option<String>> = rows.iter().map(|r| r.old_nick.clone()).collect();
+    let news: Vec<String> = rows.iter().map(|r| r.new_nick.clone()).collect();
+    let cats: Vec<String> = rows.iter().map(|r| r.category.clone()).collect();
+    sqlx::query(
+        r#"
+        INSERT INTO nick_changes (guild_id, user_id, user_name, old_nick, new_nick, category)
+        SELECT $1, uid, un, old, nn, cat
+        FROM UNNEST($2::bigint[], $3::text[], $4::text[], $5::text[], $6::text[])
+            AS t(uid, un, old, nn, cat)
+        "#,
+    )
+    .bind(gid)
+    .bind(&uids)
+    .bind(&unames)
+    .bind(&olds)
+    .bind(&news)
+    .bind(&cats)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Bulk-increment category usage counters from a `(category, delta)` list.
+pub async fn increment_category_usage_bulk(
+    pool: &PgPool,
+    guild_id: GuildId,
+    counts: &[(String, i64)],
+) -> Result<(), sqlx::Error> {
+    if counts.is_empty() {
+        return Ok(());
+    }
+    let gid = guild_id.get() as i64;
+    let cats: Vec<String> = counts.iter().map(|(c, _)| c.clone()).collect();
+    let deltas: Vec<i64> = counts.iter().map(|(_, n)| *n).collect();
+    sqlx::query(
+        r#"
+        INSERT INTO category_usage (guild_id, category_name, usage_count)
+        SELECT $1, c, n FROM UNNEST($2::text[], $3::bigint[]) AS t(c, n)
+        ON CONFLICT (guild_id, category_name) DO UPDATE
+            SET usage_count = category_usage.usage_count + EXCLUDED.usage_count
+        "#,
+    )
+    .bind(gid)
+    .bind(&cats)
+    .bind(&deltas)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// Clear used-name pool for one category, or all categories if `category` is `None`.
 pub async fn clear_used_names(
     pool: &PgPool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,8 +71,7 @@ async fn main() {
     });
 
     // GUILD_MEMBERS is a privileged intent — enable it in the Discord developer portal
-    let intents =
-        serenity::GatewayIntents::GUILDS | serenity::GatewayIntents::GUILD_MEMBERS;
+    let intents = serenity::GatewayIntents::GUILDS | serenity::GatewayIntents::GUILD_MEMBERS;
 
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,7 +28,7 @@ impl AppState {
     }
 
     pub fn guild_mut(&mut self, guild_id: GuildId) -> &mut GuildState {
-        self.guilds.entry(guild_id).or_insert_with(GuildState::new)
+        self.guilds.entry(guild_id).or_default()
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -89,7 +89,7 @@ impl GuildState {
 
         use rand::seq::SliceRandom;
         let mut rng = rand::thread_rng();
-        let picked = available.choose(&mut rng)?.to_string();
+        let picked = (*available.choose(&mut rng)?).clone();
 
         self.used_names
             .entry(category.to_string())
@@ -109,8 +109,7 @@ impl GuildState {
     ) -> Result<String, String> {
         if !all_names.iter().any(|n| n.eq_ignore_ascii_case(name)) {
             return Err(format!(
-                "**{}** is not in the **{}** category.",
-                name, category
+                "**{name}** is not in the **{category}** category."
             ));
         }
         // Find the canonical casing

--- a/src/state.rs
+++ b/src/state.rs
@@ -101,7 +101,12 @@ impl GuildState {
 
     /// Use a specific name from `category`, marking it as used.
     /// Returns an error string if the name is not in `all_names`.
-    pub fn use_specific_name(&mut self, category: &str, name: &str, all_names: &[String]) -> Result<String, String> {
+    pub fn use_specific_name(
+        &mut self,
+        category: &str,
+        name: &str,
+        all_names: &[String],
+    ) -> Result<String, String> {
         if !all_names.iter().any(|n| n.eq_ignore_ascii_case(name)) {
             return Err(format!(
                 "**{}** is not in the **{}** category.",
@@ -225,7 +230,10 @@ mod tests {
         let mut seen = std::collections::HashSet::new();
         for _ in 0..list.len() {
             let picked = gs.pick_name("test", &list).unwrap();
-            assert!(!seen.contains(&picked), "duplicate pick before pool exhausted");
+            assert!(
+                !seen.contains(&picked),
+                "duplicate pick before pool exhausted"
+            );
             seen.insert(picked);
         }
         assert_eq!(seen.len(), 3);
@@ -293,7 +301,8 @@ mod tests {
     #[test]
     fn remove_custom_category_returns_true_when_present() {
         let mut gs = GuildState::new();
-        gs.custom_categories.insert("mycat".to_string(), vec!["A".to_string()]);
+        gs.custom_categories
+            .insert("mycat".to_string(), vec!["A".to_string()]);
         assert!(gs.remove_custom_category("mycat"));
     }
 
@@ -307,7 +316,8 @@ mod tests {
     fn remove_custom_category_cleans_up_used_names() {
         let mut gs = GuildState::new();
         let list = names(&["A", "B"]);
-        gs.custom_categories.insert("mycat".to_string(), list.clone());
+        gs.custom_categories
+            .insert("mycat".to_string(), list.clone());
         gs.pick_name("mycat", &list);
         assert!(gs.used_names.contains_key("mycat"));
         gs.remove_custom_category("mycat");
@@ -317,8 +327,15 @@ mod tests {
     #[test]
     fn remove_custom_category_cleans_up_stats() {
         let mut gs = GuildState::new();
-        gs.custom_categories.insert("mycat".to_string(), vec!["A".to_string()]);
-        gs.record_change(1, "user".to_string(), None, "A".to_string(), "mycat".to_string());
+        gs.custom_categories
+            .insert("mycat".to_string(), vec!["A".to_string()]);
+        gs.record_change(
+            1,
+            "user".to_string(),
+            None,
+            "A".to_string(),
+            "mycat".to_string(),
+        );
         assert!(gs.stats.category_usage.contains_key("mycat"));
         gs.remove_custom_category("mycat");
         assert!(!gs.stats.category_usage.contains_key("mycat"));
@@ -328,8 +345,10 @@ mod tests {
     fn remove_custom_category_does_not_affect_other_categories() {
         let mut gs = GuildState::new();
         let list = names(&["X"]);
-        gs.custom_categories.insert("cat_a".to_string(), list.clone());
-        gs.custom_categories.insert("cat_b".to_string(), list.clone());
+        gs.custom_categories
+            .insert("cat_a".to_string(), list.clone());
+        gs.custom_categories
+            .insert("cat_b".to_string(), list.clone());
         gs.pick_name("cat_b", &list);
         gs.remove_custom_category("cat_a");
         assert!(gs.custom_categories.contains_key("cat_b"));
@@ -400,15 +419,33 @@ mod tests {
     #[test]
     fn record_change_increments_total_changes() {
         let mut gs = GuildState::new();
-        gs.record_change(1, "alice".to_string(), None, "Newton".to_string(), "scientists".to_string());
+        gs.record_change(
+            1,
+            "alice".to_string(),
+            None,
+            "Newton".to_string(),
+            "scientists".to_string(),
+        );
         assert_eq!(gs.stats.total_changes, 1);
     }
 
     #[test]
     fn record_change_increments_category_usage() {
         let mut gs = GuildState::new();
-        gs.record_change(1, "alice".to_string(), None, "Newton".to_string(), "scientists".to_string());
-        gs.record_change(2, "bob".to_string(), None, "Einstein".to_string(), "scientists".to_string());
+        gs.record_change(
+            1,
+            "alice".to_string(),
+            None,
+            "Newton".to_string(),
+            "scientists".to_string(),
+        );
+        gs.record_change(
+            2,
+            "bob".to_string(),
+            None,
+            "Einstein".to_string(),
+            "scientists".to_string(),
+        );
         assert_eq!(gs.stats.category_usage["scientists"], 2);
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -108,9 +108,7 @@ impl GuildState {
         all_names: &[String],
     ) -> Result<String, String> {
         if !all_names.iter().any(|n| n.eq_ignore_ascii_case(name)) {
-            return Err(format!(
-                "**{name}** is not in the **{category}** category."
-            ));
+            return Err(format!("**{name}** is not in the **{category}** category."));
         }
         // Find the canonical casing
         let canonical = all_names


### PR DESCRIPTION
## Summary
This PR significantly enhances the randomize command with a confirmation dialog, adds a new "chaos mode" for multi-category randomization, introduces a `/restore` command to undo nickname changes, and improves the category selection experience with autocomplete. It also refactors built-in categories into a JSON file and adds comprehensive test coverage.

## Key Changes

### User-Facing Features
- **Confirmation dialog**: `/randomize` now shows a confirmation button before applying changes, preventing accidental bulk renames
- **Chaos mode**: New `chaos` parameter for `/randomize` that assigns each member a name from a *different* random category
- **Restore command**: New `/restore [user]` command to revert members to their original pre-bot nicknames using recorded history
- **Category autocomplete**: The `category` parameter now autocompletes both built-in and custom categories across all commands (`/randomize`, `/nick`, `/reset_pool`)

### Code Quality & Maintainability
- **Built-in categories refactored**: Moved hardcoded category data to `src/categories.json` with compile-time embedding and caching via `OnceLock`
- **CSV import parsing**: Extracted `parse_category_csv()` as a pure, testable function in `src/commands/categories.rs`
- **Improved error handling**: Better user-facing messages for nickname edit failures and category validation
- **Database improvements**: Fixed `bulk_randomize_count` never persisting to DB by moving stats upsert outside the per-member loop
- **Comprehensive tests**: Added 30+ unit tests covering category validation, CSV parsing, nick truncation, mention escaping, and JSON integrity

### Implementation Details
- Confirmation uses Discord's button interaction system with a 60-second timeout
- Chaos mode randomly selects a category per member using `rand::seq::IteratorRandom`
- `/restore` queries the earliest `nick_changes` record per user to find their original nickname
- Built-in categories are parsed once at startup and cached for the process lifetime
- Category names are case-insensitive throughout (normalized to lowercase)
- Mention escaping now properly handles `@here` and `@everyone` with zero-width spaces
- Summary messages include `CreateAllowedMentions::new()` to prevent unintended pings

### Bug Fixes
- Fixed `bulk_randomize_count` not reaching the database (stats now persisted after bulk operation completes)
- Improved role hierarchy error messages to guide users on permission issues
- Category removal now correctly allows shadowing built-in categories

https://claude.ai/code/session_014jGjsBVTz5pmbAxBcUBJUX