### PR TITLE
fix: unbuffered stderr logging (v0.3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic-nick-names"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic-nick-names"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A Discord bot that assigns chaotic nicknames from various categories"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use poise::serenity_prelude as serenity;
+use tracing_subscriber::prelude::*;
 
 mod commands;
 mod data;
@@ -38,11 +39,18 @@ async fn main() {
     // Load optional .env file (silently ignore if absent)
     dotenv::dotenv().ok();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "chaotic_nick_names=info,warn".parse().unwrap()),
+    // Log to stderr: Rust's `Stderr` is unbuffered, so lines reach
+    // `docker logs` immediately. `Stdout` is line-buffered and a low-traffic
+    // bot can leave post-startup lines unflushed for a long time, which made
+    // the deployed bot look frozen when it was fine. Registry + layer
+    // structure mirrors our other services.
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("chaotic_nick_names=info,warn")
+            }),
         )
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .init();
 
     let token =


### PR DESCRIPTION
## Summary
- Deployed bot's `docker logs` appeared to freeze after startup — diagnosed as **stdout line-buffering**: a low-traffic Discord bot logs a startup burst then idles, leaving subsequent lines unflushed (bot was actually working the whole time).
- Switch the tracing subscriber to **stderr** (Rust's `Stderr` is unbuffered → lines hit `docker logs` immediately), restructured as `registry().with(EnvFilter).with(fmt::layer().with_writer(stderr))` to match our other services.
- Patch bump `0.3.0 → 0.3.1`.

## Test Plan
- [x] `cargo build` clean, `cargo test` 62 passed
- [ ] After merge/redeploy: trigger a command, confirm `docker --context proxmox compose logs bot` shows `InteractionCreate`/post-startup lines in real time (no more freeze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)