### PR TITLE
feat: framework-level command logging (v0.3.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,10 @@ dependencies = [
 
 [[package]]
 name = "chaotic-nick-names"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
+ "dashmap 6.2.1",
  "dotenv",
  "poise",
  "rand 0.10.1",
@@ -371,6 +372,20 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
  "serde",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1195,7 +1210,7 @@ checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -1286,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking"
@@ -1939,7 +1954,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "chrono",
- "dashmap",
+ "dashmap 5.5.3",
  "flate2",
  "futures",
  "mime_guess",
@@ -2707,7 +2722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da66c62c5b7017a2787e77373c03e6a5aafde77a73bff1ff96e91cd2e128179"
 dependencies = [
  "chrono",
- "dashmap",
+ "dashmap 5.5.3",
  "hashbrown 0.14.5",
  "mini-moka",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic-nick-names"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A Discord bot that assigns chaotic nicknames from various categories"
 
@@ -10,6 +10,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rand = "0.10"
+dashmap = "6"
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,90 @@
+//! Framework-level command logging (poise `pre_command`/`post_command`/
+//! `on_error` hooks).
+//!
+//! Emits structured start/end/error records to the process subscriber
+//! (stderr → `docker logs`). Per-invocation timing uses a `DashMap` keyed by
+//! poise's invocation id so durations survive Tokio moving the pre/post
+//! futures across worker threads (a thread-local gave `duration_ms=0` in
+//! production in `bot-template-rs`).
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use poise::FrameworkError;
+use tracing::{error, info};
+
+use crate::{Data, Error};
+
+type Ctx<'a> = poise::Context<'a, Data, Error>;
+
+static COMMAND_START_TIMES: OnceLock<DashMap<u64, Instant>> = OnceLock::new();
+
+fn start_times() -> &'static DashMap<u64, Instant> {
+    COMMAND_START_TIMES.get_or_init(DashMap::new)
+}
+
+fn guild_str(ctx: &Ctx<'_>) -> String {
+    ctx.guild_id()
+        .map_or_else(|| "DM".to_string(), |id| id.get().to_string())
+}
+
+/// `pre_command` hook: record start time and log invocation.
+pub fn log_command_start(ctx: Ctx<'_>) {
+    start_times().insert(ctx.id(), Instant::now());
+    info!(
+        command = %ctx.command().qualified_name,
+        guild_id = %guild_str(&ctx),
+        user_id = %ctx.author().id.get(),
+        event = "start",
+        "command started"
+    );
+}
+
+/// `post_command` hook: log completion with elapsed duration.
+pub fn log_command_end(ctx: Ctx<'_>) {
+    let duration_ms = start_times()
+        .remove(&ctx.id())
+        .map(|(_, start)| start.elapsed())
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    info!(
+        command = %ctx.command().qualified_name,
+        guild_id = %guild_str(&ctx),
+        user_id = %ctx.author().id.get(),
+        duration_ms,
+        event = "end",
+        "command completed"
+    );
+}
+
+/// Structured error logging. The caller still invokes
+/// `poise::builtins::on_error` afterwards, so user-facing replies (permission
+/// messages, argument errors, etc.) are preserved.
+pub fn log_command_error(err: &FrameworkError<'_, Data, Error>) {
+    match err {
+        FrameworkError::Command { error, ctx, .. } => {
+            error!(
+                command = %ctx.command().qualified_name,
+                guild_id = %guild_str(ctx),
+                user_id = %ctx.author().id.get(),
+                error = %error,
+                "command error"
+            );
+        }
+        FrameworkError::CommandCheckFailed { error, ctx, .. } => {
+            let msg = error
+                .as_ref()
+                .map_or_else(|| "check failed".to_string(), ToString::to_string);
+            error!(
+                command = %ctx.command().qualified_name,
+                guild_id = %guild_str(ctx),
+                user_id = %ctx.author().id.get(),
+                error = %msg,
+                "command check failed"
+            );
+        }
+        other => {
+            error!(error = %other, "framework error");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::prelude::*;
 mod commands;
 mod data;
 mod db;
+mod logging;
 mod state;
 
 /// Shared application data: in-memory state + Postgres connection pool.
@@ -84,9 +85,22 @@ async fn main() {
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             commands: commands::all_commands(),
-            on_error: |err| {
+            pre_command: |ctx| {
                 Box::pin(async move {
-                    if let Err(e) = poise::builtins::on_error(err).await {
+                    logging::log_command_start(ctx);
+                })
+            },
+            post_command: |ctx| {
+                Box::pin(async move {
+                    logging::log_command_end(ctx);
+                })
+            },
+            on_error: |error| {
+                Box::pin(async move {
+                    // Structured log first, then delegate to the builtin so
+                    // users still get their error/permission replies.
+                    logging::log_command_error(&error);
+                    if let Err(e) = poise::builtins::on_error(error).await {
                         tracing::error!("Unhandled error in error handler: {}", e);
                     }
                 })


### PR DESCRIPTION
## Summary
- Root finding: the bot had **no success-path logging** (only `warn!`/`error!` on failure), so `docker logs` looked frozen after startup though the bot worked.
- Adds `src/logging.rs` + poise `pre_command`/`post_command`/`on_error` hooks (mirrors `bot-template-rs`). Every command — current and future — now logs start, completion+`duration_ms`, and structured errors to the existing **stderr** subscriber (→ `docker logs`).
- **No regression:** `on_error` logs structured, then still calls `poise::builtins::on_error` so users keep their error/permission replies.
- Lite scope (per decision): no file rotation/JSON/custom targets; only new dep is `dashmap` (proven per-invocation timing — thread-local gave `duration_ms=0` in prod). Patch bump `0.3.1 → 0.3.2`.

## Test Plan
- [x] `cargo build` clean, `cargo clippy` clean, `cargo test` 62 passed
- [ ] After redeploy: invoke a command → `docker --context proxmox compose logs bot` shows `command started` / `command completed duration_ms=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)