### PR TITLE
feat: NSFW category gating (v0.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic-nick-names"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dashmap 6.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic-nick-names"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "A Discord bot that assigns chaotic nicknames from various categories"
 

--- a/src/commands/categories.rs
+++ b/src/commands/categories.rs
@@ -91,25 +91,38 @@ pub async fn list(ctx: Context<'_>) -> Result<(), Error> {
 
     let builtin_names = data::builtin_category_names();
 
-    let mut lines: Vec<String> = all_cats
-        .iter()
-        .map(|(name, items)| {
-            let tag = if builtin_names.contains(name) {
-                ""
-            } else {
-                " *(custom)*"
-            };
-            format!("• **{}**{} — {} name(s)", name, tag, items.len())
-        })
-        .collect();
-    lines.sort();
+    let format_line = |name: &String, items: &Vec<String>| {
+        let tag = if builtin_names.contains(name) {
+            ""
+        } else {
+            " *(custom)*"
+        };
+        format!("• **{}**{} — {} name(s)", name, tag, items.len())
+    };
 
-    ctx.say(format!(
-        "**Available categories** ({} total)\n{}",
-        all_cats.len(),
-        lines.join("\n")
-    ))
-    .await?;
+    let mut standard: Vec<String> = Vec::new();
+    let mut nsfw: Vec<String> = Vec::new();
+    for (name, items) in &all_cats {
+        let line = format_line(name, items);
+        if data::is_nsfw(name) {
+            nsfw.push(line);
+        } else {
+            standard.push(line);
+        }
+    }
+    standard.sort();
+    nsfw.sort();
+
+    let mut out = format!("**Available categories** ({} total)", all_cats.len());
+    if !standard.is_empty() {
+        out.push_str("\n**Standard**\n");
+        out.push_str(&standard.join("\n"));
+    }
+    if !nsfw.is_empty() {
+        out.push_str("\n\n**🔞 NSFW (18+)** — only chosen if requested explicitly\n");
+        out.push_str(&nsfw.join("\n"));
+    }
+    ctx.say(out).await?;
 
     Ok(())
 }

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -337,14 +337,28 @@ pub fn resolve_category(
         };
         Err(format!("Unknown category `{req}`. Available: {available}").into())
     } else {
-        use rand::seq::IteratorRandom;
         let mut rng = rand::rng();
-        let (k, v) = categories
-            .iter()
-            .choose(&mut rng)
+        let (k, v) = pick_random_category(categories, crate::data::is_nsfw, &mut rng)
             .ok_or("No categories available")?;
         Ok((k.clone(), v.clone()))
     }
+}
+
+/// Choose a random `(category_name, names)` pair, skipping any category for
+/// which `is_excluded(name)` returns true.
+///
+/// Factored out of [`resolve_category`] so the exclusion logic is testable
+/// independently of the live `data::is_nsfw` const.
+pub fn pick_random_category<'a>(
+    categories: &'a std::collections::HashMap<String, Vec<String>>,
+    is_excluded: impl Fn(&str) -> bool,
+    rng: &mut impl rand::Rng,
+) -> Option<(&'a String, &'a Vec<String>)> {
+    use rand::seq::IteratorRandom;
+    categories
+        .iter()
+        .filter(|(name, _)| !is_excluded(name))
+        .choose(rng)
 }
 
 /// Truncate a potential nickname to Discord's 32-character limit,
@@ -540,5 +554,59 @@ mod tests {
     fn resolve_category_empty_map_returns_error() {
         let cats: HashMap<String, Vec<String>> = HashMap::new();
         assert!(resolve_category(&cats, None).is_err());
+    }
+
+    // ── NSFW exclusion (pick_random_category) ──────────────────────────────
+
+    fn cats_with_nsfw() -> HashMap<String, Vec<String>> {
+        let mut m = HashMap::new();
+        m.insert("scientists".into(), vec!["Einstein".into()]);
+        m.insert("serial_killers".into(), vec!["Some Name".into()]);
+        m
+    }
+
+    #[test]
+    fn pick_random_category_excludes_nsfw_names() {
+        let cats = cats_with_nsfw();
+        let mut rng = rand::rng();
+        // Run many times; the NSFW name must never appear in the random pool.
+        for _ in 0..200 {
+            let (name, _) = pick_random_category(&cats, |n| n == "serial_killers", &mut rng)
+                .expect("should pick a non-NSFW category");
+            assert_ne!(name, "serial_killers");
+        }
+    }
+
+    #[test]
+    fn pick_random_category_returns_none_when_all_excluded() {
+        let cats = cats_with_nsfw();
+        let mut rng = rand::rng();
+        assert!(pick_random_category(&cats, |_| true, &mut rng).is_none());
+    }
+
+    #[test]
+    fn pick_random_category_no_exclusions_picks_anything() {
+        let cats = cats_with_nsfw();
+        let mut rng = rand::rng();
+        let (name, _) = pick_random_category(&cats, |_| false, &mut rng).unwrap();
+        assert!(cats.contains_key(name));
+    }
+
+    #[test]
+    fn resolve_category_random_skips_nsfw_with_live_is_nsfw() {
+        // With production is_nsfw (currently empty), random selection works
+        // exactly as before — sanity-check that the wiring didn't break it.
+        let cats = sample_categories();
+        let (name, _) = resolve_category(&cats, None).unwrap();
+        assert!(cats.contains_key(&name));
+    }
+
+    #[test]
+    fn resolve_category_explicit_request_allows_nsfw() {
+        // Even if "serial_killers" were declared NSFW in prod, an explicit
+        // request for it must be honoured (user opt-in).
+        let cats = cats_with_nsfw();
+        let (name, _) = resolve_category(&cats, Some("serial_killers")).unwrap();
+        assert_eq!(name, "serial_killers");
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -25,6 +25,19 @@ pub fn builtin_category_names() -> Vec<String> {
     names
 }
 
+/// Category names that are NSFW / 18+. They remain in the catalog and can be
+/// invoked explicitly (e.g. `/randomize category:serial_killers`) but are
+/// excluded from random-pool selection by default — see
+/// `randomize::pick_random_category`. Listed names MUST exist as real
+/// categories in `categories.json` (enforced by a test below); add an entry
+/// here in the same PR that adds the category's data.
+pub const NSFW: &[&str] = &[];
+
+/// Case-insensitive membership test against [`NSFW`].
+pub fn is_nsfw(name: &str) -> bool {
+    NSFW.iter().any(|n| n.eq_ignore_ascii_case(name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -33,6 +46,29 @@ mod tests {
     fn builtin_categories_is_non_empty() {
         let cats = builtin_categories();
         assert!(!cats.is_empty());
+    }
+
+    #[test]
+    fn nsfw_names_are_real_categories() {
+        let cats = builtin_categories();
+        for name in NSFW {
+            assert!(
+                cats.contains_key(*name),
+                "NSFW entry '{}' is not a real category in categories.json",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn is_nsfw_is_case_insensitive() {
+        // Vacuously true while NSFW is empty; exercises the predicate so any
+        // future addition is regression-tested for casing.
+        for name in NSFW {
+            assert!(is_nsfw(name));
+            assert!(is_nsfw(&name.to_uppercase()));
+        }
+        assert!(!is_nsfw("definitely_not_a_real_nsfw_category_zzz"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Default `/randomize` random-pool selection now **excludes** any category in `data::NSFW`. Explicit `category: <name>` requests still resolve normally — user opt-in is preserved (matches the "21+ CAH baseline, but explicitly NSFW is opt-in" design).

- `src/data.rs`: `pub const NSFW: &[&str] = &[]` + `pub fn is_nsfw(name) -> bool` (case-insensitive). Test enforces every NSFW entry is a real category in `categories.json`.
- `src/commands/randomize.rs`: new `pick_random_category(cats, is_excluded, rng)` helper; `resolve_category`'s random branch routes through it with `data::is_nsfw`. Five new tests covering exclusion, all-excluded edge case, no-exclusions baseline, the live-`is_nsfw` wire-up, and explicit-request-allows-NSFW.
- `src/commands/categories.rs`: `/categories list` now renders Standard + 🔞 NSFW (18+) sections; the NSFW section is hidden when empty (no visible change yet on master).
- Minor bump `0.3.2 → 0.4.0` (user-visible behavior change in `/randomize`).

## Activation
NSFW const ships empty. To activate (e.g. for `serial_killers` once it lands in `categories.json`): add `"serial_killers"` to `NSFW` in `src/data.rs` — that's the entire change. The `nsfw_names_are_real_categories` test will fail loudly if you add a name that isn't actually in the catalog.

## Test Plan
- [x] `cargo build` clean, `cargo clippy` clean, `cargo test` **69 passed** (was 62; +2 in data.rs, +5 in randomize.rs)
- [ ] After merge/redeploy with NSFW=`["serial_killers"]` (in a follow-up PR once the category exists): `/randomize` (no args) never picks serial_killers across many runs; `/randomize category:serial_killers` works; `/categories list` shows two sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)