### PR TITLE
feat: nickname feedback context-menu command

### DIFF
--- a/migrations/002_feedback.sql
+++ b/migrations/002_feedback.sql
@@ -1,0 +1,23 @@
+-- Per-user feedback on a specific nickname assignment (FK → nick_changes).
+-- One row per (assignment, submitter); resubmission is an UPDATE via
+-- the unique constraint and ON CONFLICT DO UPDATE in upsert_feedback.
+
+-- Speed up the "this user's most recent nick change in this guild within
+-- N days" lookup used by the feedback context-menu command. The existing
+-- (guild_id, changed_at DESC) index doesn't help a user-scoped query.
+CREATE INDEX IF NOT EXISTS nick_changes_guild_user_idx
+    ON nick_changes (guild_id, user_id, changed_at DESC);
+
+CREATE TABLE IF NOT EXISTS feedback (
+    id                    BIGSERIAL    PRIMARY KEY,
+    nick_change_id        BIGINT       NOT NULL
+                                         REFERENCES nick_changes(id)
+                                         ON DELETE CASCADE,
+    submitted_by          BIGINT       NOT NULL,
+    is_relevant           BOOLEAN,                 -- NULL = no opinion / skipped
+    nsfw_miscategorized   BOOLEAN      NOT NULL DEFAULT FALSE,
+    note                  VARCHAR(140),
+    resolved_at           TIMESTAMPTZ,             -- for the future admin panel
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (nick_change_id, submitted_by)
+);

--- a/src/commands/feedback.rs
+++ b/src/commands/feedback.rs
@@ -1,0 +1,468 @@
+use std::time::Duration;
+
+use poise::serenity_prelude::{self as serenity, futures::StreamExt};
+
+use crate::db;
+use crate::{Data, Error};
+
+/// How far back to look for an assignment to attach feedback to. Older
+/// nicknames are usually long-forgotten by the wearer, so feedback on them
+/// is rarely useful and risks being noise for category curation.
+const RECENT_DAYS: i32 = 30;
+
+/// Maximum time the ephemeral feedback session waits for further clicks
+/// before timing out. Discord's interaction token also limits this to 15
+/// minutes, so we stay well under that.
+const SESSION_TIMEOUT: Duration = Duration::from_secs(300);
+
+const NOTE_MAX_LEN: usize = 140;
+
+/// Modal opened when the user clicks "Add note". Pre-filled with whatever
+/// note the user typed earlier in the same session, if any.
+#[derive(Debug, poise::Modal)]
+#[name = "Feedback note"]
+struct NoteModal {
+    #[name = "Optional note (max 140 chars)"]
+    #[placeholder = "What about this nickname surprised, annoyed, or delighted you?"]
+    #[paragraph]
+    #[min_length = 0]
+    #[max_length = 140]
+    note: Option<String>,
+}
+
+/// The "Is this nickname relevant to {category}?" tri-state. `Unset` is the
+/// initial pre-interaction state and is treated as `NULL is_relevant` in the
+/// DB; `Skip` is an explicit user-chosen "no opinion".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Relevance {
+    Unset,
+    Yes,
+    No,
+    Skip,
+}
+
+impl Relevance {
+    fn to_db_value(self) -> Option<bool> {
+        match self {
+            Relevance::Yes => Some(true),
+            Relevance::No => Some(false),
+            Relevance::Unset | Relevance::Skip => None,
+        }
+    }
+}
+
+/// Mutable feedback state that lives only on the stack for the duration of
+/// the ephemeral session — discarded on submit, cancel, or timeout.
+#[derive(Debug)]
+struct FeedbackState {
+    relevance: Relevance,
+    nsfw_flag: bool,
+    note: Option<String>,
+}
+
+/// Right-click yourself → Apps → **Give feedback on nickname**. Captures
+/// per-nickname signal (relevance to category, NSFW miscategorization,
+/// optional free-text note) and stores it in the `feedback` table keyed by
+/// the originating `nick_changes` row.
+#[poise::command(context_menu_command = "Give feedback on nickname", guild_only)]
+pub async fn give_feedback(
+    ctx: poise::ApplicationContext<'_, Data, Error>,
+    user: serenity::User,
+) -> Result<(), Error> {
+    // Self-only for v1. Right-clicking someone else is rejected with a clear
+    // ephemeral message; future versions may relax this for moderators.
+    if user.id != ctx.interaction.user.id {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("You can only give feedback on your own nickname (for now).")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let guild_id = ctx.guild_id().ok_or("guild_only command outside guild")?;
+
+    // The DB has the full history; the in-memory deque is capped at 200 so
+    // a bulk randomize on a large guild can evict assignments we still want
+    // to surface here. Query directly.
+    let nc = match db::find_recent_nick_change(&ctx.data.db, guild_id, user.id.get(), RECENT_DAYS)
+        .await?
+    {
+        Some(row) => row,
+        None => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .content(format!(
+                        "I haven't assigned you a nickname in the last {RECENT_DAYS} days. \
+                         Try `/assign_random_nick` first, then come back to give feedback."
+                    ))
+                    .ephemeral(true),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    // Scope every custom_id to this command invocation so other in-flight
+    // feedback sessions don't catch each other's button clicks.
+    let invocation_id = ctx.interaction.id;
+    let id_relevance = format!("fb-rel-{invocation_id}");
+    let id_nsfw = format!("fb-nsfw-{invocation_id}");
+    let id_note = format!("fb-note-{invocation_id}");
+    let id_submit = format!("fb-submit-{invocation_id}");
+    let id_cancel = format!("fb-cancel-{invocation_id}");
+
+    let mut state = FeedbackState {
+        relevance: Relevance::Unset,
+        nsfw_flag: false,
+        note: None,
+    };
+
+    // Initial ephemeral render.
+    let reply = build_reply(
+        &nc,
+        &state,
+        &id_relevance,
+        &id_nsfw,
+        &id_note,
+        &id_submit,
+        &id_cancel,
+    );
+    let prompt = ctx.send(reply.ephemeral(true)).await?;
+    let msg_id = prompt.message().await?.id;
+    let parent_ctx: crate::Context<'_> = poise::Context::Application(ctx);
+
+    // Stream every component interaction on this message until the user
+    // submits, cancels, or the session times out.
+    let mut stream = serenity::ComponentInteractionCollector::new(ctx.serenity_context())
+        .author_id(user.id)
+        .message_id(msg_id)
+        .timeout(SESSION_TIMEOUT)
+        .stream();
+
+    while let Some(mci) = stream.next().await {
+        let cid = mci.data.custom_id.as_str();
+
+        if cid == id_relevance {
+            if let serenity::ComponentInteractionDataKind::StringSelect { values } = &mci.data.kind
+            {
+                state.relevance = match values.first().map(String::as_str) {
+                    Some("yes") => Relevance::Yes,
+                    Some("no") => Relevance::No,
+                    Some("skip") => Relevance::Skip,
+                    _ => Relevance::Unset,
+                };
+            }
+            mci.create_response(
+                ctx.serenity_context(),
+                serenity::CreateInteractionResponse::UpdateMessage(build_response_message(
+                    &nc,
+                    &state,
+                    &id_relevance,
+                    &id_nsfw,
+                    &id_note,
+                    &id_submit,
+                    &id_cancel,
+                )),
+            )
+            .await?;
+        } else if cid == id_nsfw {
+            state.nsfw_flag = !state.nsfw_flag;
+            mci.create_response(
+                ctx.serenity_context(),
+                serenity::CreateInteractionResponse::UpdateMessage(build_response_message(
+                    &nc,
+                    &state,
+                    &id_relevance,
+                    &id_nsfw,
+                    &id_note,
+                    &id_submit,
+                    &id_cancel,
+                )),
+            )
+            .await?;
+        } else if cid == id_note {
+            // Open a modal pre-filled with the existing note. The modal
+            // submission auto-acks; we then have to repaint the original
+            // ephemeral message ourselves via the reply handle.
+            let prefilled = NoteModal {
+                note: state.note.clone(),
+            };
+            let result = poise::execute_modal_on_component_interaction(
+                ctx,
+                mci,
+                Some(prefilled),
+                Some(Duration::from_secs(120)),
+            )
+            .await?;
+            if let Some(NoteModal { note }) = result {
+                state.note = note
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty());
+                let refreshed = build_reply(
+                    &nc,
+                    &state,
+                    &id_relevance,
+                    &id_nsfw,
+                    &id_note,
+                    &id_submit,
+                    &id_cancel,
+                );
+                prompt.edit(parent_ctx, refreshed.ephemeral(true)).await?;
+            }
+            // If the modal was dismissed (result == None), leave state alone.
+        } else if cid == id_submit {
+            db::upsert_feedback(
+                &ctx.data.db,
+                nc.id,
+                user.id.get(),
+                state.relevance.to_db_value(),
+                state.nsfw_flag,
+                state.note.as_deref(),
+            )
+            .await?;
+            tracing::info!(
+                "feedback recorded: nick_change={} user={} relevant={:?} nsfw_flag={} note_len={}",
+                nc.id,
+                user.id.get(),
+                state.relevance,
+                state.nsfw_flag,
+                state.note.as_deref().map(str::len).unwrap_or(0),
+            );
+            mci.create_response(
+                ctx.serenity_context(),
+                serenity::CreateInteractionResponse::UpdateMessage(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content(format!(
+                            "✅ Feedback recorded for **{}** (*{}*). Thanks!",
+                            nc.new_nick, nc.category
+                        ))
+                        .components(vec![]),
+                ),
+            )
+            .await?;
+            return Ok(());
+        } else if cid == id_cancel {
+            mci.create_response(
+                ctx.serenity_context(),
+                serenity::CreateInteractionResponse::UpdateMessage(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("Feedback cancelled — nothing was saved.")
+                        .components(vec![]),
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+        // Unknown custom_ids are ignored (defensive; shouldn't fire with
+        // invocation-scoped IDs).
+    }
+
+    // Stream ended without an explicit submit / cancel ⇒ session timed out.
+    // best-effort edit; ignore failure (interaction token may be expired).
+    let _ = prompt
+        .edit(
+            parent_ctx,
+            poise::CreateReply::default()
+                .content(format!(
+                    "⏱️ Feedback session timed out after {} minutes — no feedback saved.",
+                    SESSION_TIMEOUT.as_secs() / 60
+                ))
+                .components(vec![])
+                .ephemeral(true),
+        )
+        .await;
+
+    Ok(())
+}
+
+// ── View helpers ─────────────────────────────────────────────────────────────
+
+/// Render the message body shared by the initial send and every modal-driven
+/// re-render. Returns the text only; components are added by the caller.
+fn body_text(nc: &db::RecentNickChange, state: &FeedbackState) -> String {
+    let when = nc.changed_at.format("%Y-%m-%d %H:%M UTC");
+    let mut s = format!(
+        "**Feedback on:** `{}` *({})*  · changed {}\n\n",
+        nc.new_nick, nc.category, when
+    );
+    s.push_str(match state.relevance {
+        Relevance::Unset => "• Relevance: *(not selected)*\n",
+        Relevance::Yes => "• Relevance: ✅ relevant\n",
+        Relevance::No => "• Relevance: ❌ not relevant\n",
+        Relevance::Skip => "• Relevance: ⏭️ skipped\n",
+    });
+    s.push_str(&format!(
+        "• NSFW miscategorized flag: {}\n",
+        if state.nsfw_flag { "🔞 yes" } else { "—" }
+    ));
+    let note_preview = state.note.as_deref().unwrap_or("");
+    if note_preview.is_empty() {
+        s.push_str("• Note: *(none)*\n");
+    } else {
+        let truncated = if note_preview.len() > NOTE_MAX_LEN {
+            format!("{}…", &note_preview[..NOTE_MAX_LEN])
+        } else {
+            note_preview.to_string()
+        };
+        s.push_str(&format!("• Note: {truncated}\n"));
+    }
+    s
+}
+
+/// Build all four component rows. The StringSelect's `default_selection`
+/// reflects current state so the UI matches what the user already chose;
+/// the NSFW button label/style and the Note button label flip with state.
+fn components(
+    state: &FeedbackState,
+    id_relevance: &str,
+    id_nsfw: &str,
+    id_note: &str,
+    id_submit: &str,
+    id_cancel: &str,
+) -> Vec<serenity::CreateActionRow> {
+    let opt = |value: &str, label: &str, this: Relevance| {
+        serenity::CreateSelectMenuOption::new(label, value).default_selection(state.relevance == this)
+    };
+    let select = serenity::CreateSelectMenu::new(
+        id_relevance,
+        serenity::CreateSelectMenuKind::String {
+            options: vec![
+                opt("yes", "Yes — relevant to the category", Relevance::Yes),
+                opt("no", "No — not relevant", Relevance::No),
+                opt("skip", "Skip / no opinion", Relevance::Skip),
+            ],
+        },
+    )
+    .placeholder("Is this nickname relevant to the category?")
+    .min_values(1)
+    .max_values(1);
+
+    let nsfw_btn = serenity::CreateButton::new(id_nsfw)
+        .label(if state.nsfw_flag {
+            "🔞 Flagged as NSFW ✓"
+        } else {
+            "🔞 Flag as NSFW miscategorized"
+        })
+        .style(if state.nsfw_flag {
+            serenity::ButtonStyle::Danger
+        } else {
+            serenity::ButtonStyle::Secondary
+        });
+    let note_btn = serenity::CreateButton::new(id_note)
+        .label(if state.note.is_some() {
+            "📝 Edit note"
+        } else {
+            "📝 Add note (optional)"
+        })
+        .style(serenity::ButtonStyle::Secondary);
+    let submit_btn = serenity::CreateButton::new(id_submit)
+        .label("Submit")
+        .style(serenity::ButtonStyle::Primary);
+    let cancel_btn = serenity::CreateButton::new(id_cancel)
+        .label("Cancel")
+        .style(serenity::ButtonStyle::Secondary);
+
+    vec![
+        serenity::CreateActionRow::SelectMenu(select),
+        serenity::CreateActionRow::Buttons(vec![nsfw_btn, note_btn]),
+        serenity::CreateActionRow::Buttons(vec![submit_btn, cancel_btn]),
+    ]
+}
+
+fn build_reply(
+    nc: &db::RecentNickChange,
+    state: &FeedbackState,
+    id_relevance: &str,
+    id_nsfw: &str,
+    id_note: &str,
+    id_submit: &str,
+    id_cancel: &str,
+) -> poise::CreateReply {
+    poise::CreateReply::default()
+        .content(body_text(nc, state))
+        .components(components(
+            state,
+            id_relevance,
+            id_nsfw,
+            id_note,
+            id_submit,
+            id_cancel,
+        ))
+}
+
+fn build_response_message(
+    nc: &db::RecentNickChange,
+    state: &FeedbackState,
+    id_relevance: &str,
+    id_nsfw: &str,
+    id_note: &str,
+    id_submit: &str,
+    id_cancel: &str,
+) -> serenity::CreateInteractionResponseMessage {
+    serenity::CreateInteractionResponseMessage::new()
+        .content(body_text(nc, state))
+        .components(components(
+            state,
+            id_relevance,
+            id_nsfw,
+            id_note,
+            id_submit,
+            id_cancel,
+        ))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relevance_to_db_value_maps_correctly() {
+        assert_eq!(Relevance::Unset.to_db_value(), None);
+        assert_eq!(Relevance::Skip.to_db_value(), None);
+        assert_eq!(Relevance::Yes.to_db_value(), Some(true));
+        assert_eq!(Relevance::No.to_db_value(), Some(false));
+    }
+
+    #[test]
+    fn body_text_reflects_state() {
+        let nc = db::RecentNickChange {
+            id: 42,
+            category: "scientists".into(),
+            new_nick: "Marie Curie".into(),
+            changed_at: chrono::Utc::now(),
+        };
+        let state = FeedbackState {
+            relevance: Relevance::Yes,
+            nsfw_flag: true,
+            note: Some("perfect match".into()),
+        };
+        let body = body_text(&nc, &state);
+        assert!(body.contains("Marie Curie"));
+        assert!(body.contains("scientists"));
+        assert!(body.contains("✅ relevant"));
+        assert!(body.contains("🔞 yes"));
+        assert!(body.contains("perfect match"));
+    }
+
+    #[test]
+    fn body_text_handles_empty_state() {
+        let nc = db::RecentNickChange {
+            id: 1,
+            category: "spices".into(),
+            new_nick: "Cumin".into(),
+            changed_at: chrono::Utc::now(),
+        };
+        let state = FeedbackState {
+            relevance: Relevance::Unset,
+            nsfw_flag: false,
+            note: None,
+        };
+        let body = body_text(&nc, &state);
+        assert!(body.contains("*(not selected)*"));
+        assert!(body.contains("Note: *(none)*"));
+    }
+}

--- a/src/commands/feedback.rs
+++ b/src/commands/feedback.rs
@@ -15,8 +15,6 @@ const RECENT_DAYS: i32 = 30;
 /// minutes, so we stay well under that.
 const SESSION_TIMEOUT: Duration = Duration::from_secs(300);
 
-const NOTE_MAX_LEN: usize = 140;
-
 /// Modal opened when the user clicks "Add note". Pre-filled with whatever
 /// note the user typed earlier in the same session, if any.
 #[derive(Debug, poise::Modal)]
@@ -119,17 +117,38 @@ pub async fn give_feedback(
         note: None,
     };
 
+    // Each render closure returns an owned builder so the inner FeedbackView
+    // (which borrows both the captured refs and the per-call state ref)
+    // doesn't leak its lifetimes into the caller. Two closures rather than
+    // one because `to_reply()` and `to_response_message()` produce distinct
+    // builder types.
+    let render_reply = |s: &FeedbackState| {
+        FeedbackView {
+            nc: &nc,
+            state: s,
+            id_relevance: &id_relevance,
+            id_nsfw: &id_nsfw,
+            id_note: &id_note,
+            id_submit: &id_submit,
+            id_cancel: &id_cancel,
+        }
+        .to_reply()
+    };
+    let render_response = |s: &FeedbackState| {
+        FeedbackView {
+            nc: &nc,
+            state: s,
+            id_relevance: &id_relevance,
+            id_nsfw: &id_nsfw,
+            id_note: &id_note,
+            id_submit: &id_submit,
+            id_cancel: &id_cancel,
+        }
+        .to_response_message()
+    };
+
     // Initial ephemeral render.
-    let reply = build_reply(
-        &nc,
-        &state,
-        &id_relevance,
-        &id_nsfw,
-        &id_note,
-        &id_submit,
-        &id_cancel,
-    );
-    let prompt = ctx.send(reply.ephemeral(true)).await?;
+    let prompt = ctx.send(render_reply(&state).ephemeral(true)).await?;
     let msg_id = prompt.message().await?.id;
     let parent_ctx: crate::Context<'_> = poise::Context::Application(ctx);
 
@@ -154,34 +173,8 @@ pub async fn give_feedback(
                     _ => Relevance::Unset,
                 };
             }
-            mci.create_response(
-                ctx.serenity_context(),
-                serenity::CreateInteractionResponse::UpdateMessage(build_response_message(
-                    &nc,
-                    &state,
-                    &id_relevance,
-                    &id_nsfw,
-                    &id_note,
-                    &id_submit,
-                    &id_cancel,
-                )),
-            )
-            .await?;
         } else if cid == id_nsfw {
             state.nsfw_flag = !state.nsfw_flag;
-            mci.create_response(
-                ctx.serenity_context(),
-                serenity::CreateInteractionResponse::UpdateMessage(build_response_message(
-                    &nc,
-                    &state,
-                    &id_relevance,
-                    &id_nsfw,
-                    &id_note,
-                    &id_submit,
-                    &id_cancel,
-                )),
-            )
-            .await?;
         } else if cid == id_note {
             // Open a modal pre-filled with the existing note. The modal
             // submission auto-acks; we then have to repaint the original
@@ -200,18 +193,12 @@ pub async fn give_feedback(
                 state.note = note
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty());
-                let refreshed = build_reply(
-                    &nc,
-                    &state,
-                    &id_relevance,
-                    &id_nsfw,
-                    &id_note,
-                    &id_submit,
-                    &id_cancel,
-                );
-                prompt.edit(parent_ctx, refreshed.ephemeral(true)).await?;
+                prompt
+                    .edit(parent_ctx, render_reply(&state).ephemeral(true))
+                    .await?;
             }
             // If the modal was dismissed (result == None), leave state alone.
+            continue;
         } else if cid == id_submit {
             db::upsert_feedback(
                 &ctx.data.db,
@@ -254,9 +241,19 @@ pub async fn give_feedback(
             )
             .await?;
             return Ok(());
+        } else {
+            // Unknown custom_id (shouldn't fire with invocation-scoped IDs).
+            continue;
         }
-        // Unknown custom_ids are ignored (defensive; shouldn't fire with
-        // invocation-scoped IDs).
+
+        // Reached by id_relevance and id_nsfw branches only — the others
+        // diverged via `continue` or `return` after handling their own
+        // response. Repaint the prompt with the just-mutated state.
+        mci.create_response(
+            ctx.serenity_context(),
+            serenity::CreateInteractionResponse::UpdateMessage(render_response(&state)),
+        )
+        .await?;
     }
 
     // Stream ended without an explicit submit / cancel ⇒ session timed out.
@@ -297,16 +294,11 @@ fn body_text(nc: &db::RecentNickChange, state: &FeedbackState) -> String {
         "• NSFW miscategorized flag: {}\n",
         if state.nsfw_flag { "🔞 yes" } else { "—" }
     ));
-    let note_preview = state.note.as_deref().unwrap_or("");
-    if note_preview.is_empty() {
-        s.push_str("• Note: *(none)*\n");
-    } else {
-        let truncated = if note_preview.len() > NOTE_MAX_LEN {
-            format!("{}…", &note_preview[..NOTE_MAX_LEN])
-        } else {
-            note_preview.to_string()
-        };
-        s.push_str(&format!("• Note: {truncated}\n"));
+    match state.note.as_deref() {
+        // The modal enforces max_length=140 server-side, so anything we see
+        // here already fits — no manual truncation needed.
+        None | Some("") => s.push_str("• Note: *(none)*\n"),
+        Some(note) => s.push_str(&format!("• Note: {note}\n")),
     }
     s
 }
@@ -371,46 +363,51 @@ fn components(
     ]
 }
 
-fn build_reply(
-    nc: &db::RecentNickChange,
-    state: &FeedbackState,
-    id_relevance: &str,
-    id_nsfw: &str,
-    id_note: &str,
-    id_submit: &str,
-    id_cancel: &str,
-) -> poise::CreateReply {
-    poise::CreateReply::default()
-        .content(body_text(nc, state))
-        .components(components(
-            state,
-            id_relevance,
-            id_nsfw,
-            id_note,
-            id_submit,
-            id_cancel,
-        ))
+/// A bundle of references that together render the feedback prompt. Holds
+/// just the inputs `body_text` and `components` need, so callers don't have
+/// to thread seven arguments through every `build_*` site. Methods provide
+/// the two builders (`poise::CreateReply` for the initial ephemeral send and
+/// for `ReplyHandle::edit`, `CreateInteractionResponseMessage` for
+/// component-interaction `UpdateMessage` responses).
+struct FeedbackView<'a> {
+    nc: &'a db::RecentNickChange,
+    state: &'a FeedbackState,
+    id_relevance: &'a str,
+    id_nsfw: &'a str,
+    id_note: &'a str,
+    id_submit: &'a str,
+    id_cancel: &'a str,
 }
 
-fn build_response_message(
-    nc: &db::RecentNickChange,
-    state: &FeedbackState,
-    id_relevance: &str,
-    id_nsfw: &str,
-    id_note: &str,
-    id_submit: &str,
-    id_cancel: &str,
-) -> serenity::CreateInteractionResponseMessage {
-    serenity::CreateInteractionResponseMessage::new()
-        .content(body_text(nc, state))
-        .components(components(
-            state,
-            id_relevance,
-            id_nsfw,
-            id_note,
-            id_submit,
-            id_cancel,
-        ))
+impl FeedbackView<'_> {
+    fn content(&self) -> String {
+        body_text(self.nc, self.state)
+    }
+
+    fn rows(&self) -> Vec<serenity::CreateActionRow> {
+        // Calls the free `components` fn — `self.rows()` would be ambiguous
+        // with this method name otherwise.
+        components(
+            self.state,
+            self.id_relevance,
+            self.id_nsfw,
+            self.id_note,
+            self.id_submit,
+            self.id_cancel,
+        )
+    }
+
+    fn to_reply(&self) -> poise::CreateReply {
+        poise::CreateReply::default()
+            .content(self.content())
+            .components(self.rows())
+    }
+
+    fn to_response_message(&self) -> serenity::CreateInteractionResponseMessage {
+        serenity::CreateInteractionResponseMessage::new()
+            .content(self.content())
+            .components(self.rows())
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod categories;
 pub mod context_menu;
+pub mod feedback;
 pub mod history;
 pub mod nick;
 pub mod randomize;
@@ -20,5 +21,6 @@ pub fn all_commands() -> Vec<poise::Command<Data, Error>> {
         reset::reset_pool(),
         restore::restore(),
         context_menu::assign_random_nick(),
+        feedback::give_feedback(),
     ]
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use chrono::{DateTime, Utc};
 use poise::serenity_prelude::GuildId;
 use sqlx::{postgres::PgPoolOptions, PgPool, Row};
 
@@ -8,15 +9,21 @@ use crate::state::{GuildState, GuildStats, HistoryEntry};
 // ── Pool setup ────────────────────────────────────────────────────────────────
 
 /// Connect to Postgres, run pending migrations, and return the pool.
+/// Migrations are listed explicitly so the boot order is obvious; each file
+/// is idempotent (`IF NOT EXISTS`) so re-running on an up-to-date schema is
+/// a no-op.
 pub async fn setup(database_url: &str) -> Result<PgPool, sqlx::Error> {
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(database_url)
         .await?;
 
-    sqlx::raw_sql(include_str!("../migrations/001_initial.sql"))
-        .execute(&pool)
-        .await?;
+    for sql in [
+        include_str!("../migrations/001_initial.sql"),
+        include_str!("../migrations/002_feedback.sql"),
+    ] {
+        sqlx::raw_sql(sql).execute(&pool).await?;
+    }
 
     Ok(pool)
 }
@@ -458,6 +465,85 @@ pub async fn increment_category_usage(
     )
     .bind(gid)
     .bind(category)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── Feedback lookups ─────────────────────────────────────────────────────────
+
+/// A minimal projection of a `nick_changes` row used by the feedback flow:
+/// just the fields needed to render the prompt and to attach feedback by FK.
+#[derive(Debug, Clone)]
+pub struct RecentNickChange {
+    pub id: i64,
+    pub category: String,
+    pub new_nick: String,
+    pub changed_at: DateTime<Utc>,
+}
+
+/// Most recent `nick_changes` row for `(guild_id, user_id)` within the last
+/// `days` days, or `None` if no qualifying row exists.
+pub async fn find_recent_nick_change(
+    pool: &PgPool,
+    guild_id: GuildId,
+    user_id: u64,
+    days: i32,
+) -> Result<Option<RecentNickChange>, sqlx::Error> {
+    let row = sqlx::query(
+        r"
+        SELECT id, category, new_nick, changed_at
+        FROM nick_changes
+        WHERE guild_id = $1
+          AND user_id  = $2
+          AND changed_at > NOW() - ($3::int * INTERVAL '1 day')
+        ORDER BY changed_at DESC
+        LIMIT 1
+        ",
+    )
+    .bind(guild_id.get() as i64)
+    .bind(user_id as i64)
+    .bind(days)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|r| RecentNickChange {
+        id: r.get("id"),
+        category: r.get("category"),
+        new_nick: r.get("new_nick"),
+        changed_at: r.get("changed_at"),
+    }))
+}
+
+/// Insert or update one feedback row for `(nick_change_id, submitted_by)`.
+/// Resubmissions overwrite prior values and refresh `created_at` to act
+/// like a "last edited at" — this keeps the table small and prevents
+/// duplicate feedback per assignment from one user.
+pub async fn upsert_feedback(
+    pool: &PgPool,
+    nick_change_id: i64,
+    submitted_by: u64,
+    is_relevant: Option<bool>,
+    nsfw_miscategorized: bool,
+    note: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r"
+        INSERT INTO feedback
+            (nick_change_id, submitted_by, is_relevant, nsfw_miscategorized, note)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (nick_change_id, submitted_by) DO UPDATE
+            SET is_relevant         = EXCLUDED.is_relevant,
+                nsfw_miscategorized = EXCLUDED.nsfw_miscategorized,
+                note                = EXCLUDED.note,
+                created_at          = NOW()
+        ",
+    )
+    .bind(nick_change_id)
+    .bind(submitted_by as i64)
+    .bind(is_relevant)
+    .bind(nsfw_miscategorized)
+    .bind(note)
     .execute(pool)
     .await?;
     Ok(())


### PR DESCRIPTION
## Summary

Right-click yourself → Apps → **Give feedback on nickname** opens an ephemeral prompt capturing three signals about a recent bot-assigned nickname:

- **Relevance** to the chosen category (Yes / No / Skip)
- **NSFW miscategorized** flag (the nick is NSFW but the category isn't)
- **Optional note** (up to 140 characters)

UX is a components + modal hybrid:
- StringSelect for relevance with `default_selection` mirroring state.
- Toggle button for the NSFW flag (label + style flip on each click).
- "Add/Edit note" button opens a `poise::Modal` pre-filled with prior text.
- Submit / Cancel close the session; otherwise 5-minute timeout.

## Schema

New migration `002_feedback.sql`:

```sql
CREATE INDEX IF NOT EXISTS nick_changes_guild_user_idx
    ON nick_changes (guild_id, user_id, changed_at DESC);

CREATE TABLE IF NOT EXISTS feedback (
    id                    BIGSERIAL    PRIMARY KEY,
    nick_change_id        BIGINT       NOT NULL
                                         REFERENCES nick_changes(id)
                                         ON DELETE CASCADE,
    submitted_by          BIGINT       NOT NULL,
    is_relevant           BOOLEAN,
    nsfw_miscategorized   BOOLEAN      NOT NULL DEFAULT FALSE,
    note                  VARCHAR(140),
    resolved_at           TIMESTAMPTZ,
    created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
    UNIQUE (nick_change_id, submitted_by)
);
```

`db::setup()` now chains both migrations in an explicit list; each is idempotent (`IF NOT EXISTS`) so re-running on an up-to-date schema is a no-op. The `resolved_at` column is included now to save a migration when the admin-panel feature lands later.

## Scope (intentionally minimal)

- **Self-only for v1** — right-clicking another user is rejected with a clear ephemeral message. Future work may relax this for users with `Manage Nicknames`.
- **30-day recency window** — if there's no `nick_changes` row for `(guild, user)` in the last 30 days, the bot suggests `/assign_random_nick` first instead of attaching feedback to an ancient nick the user no longer remembers.
- **Reuses existing `nick_changes`** — no new "assignments" table. The original plan duplicated this; we use the FK to the existing change log.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 72 passing (3 new unit tests in `feedback.rs` covering `Relevance::to_db_value` and body rendering for filled / empty state)
- [ ] **Manual smoke after deploy** (Discord interaction can't be unit-tested):
  - Right-click self → Apps → Give feedback on nickname → modal flow completes and writes a row
  - Verify resubmission updates rather than duplicates (UNIQUE constraint + ON CONFLICT)
  - Verify right-clicking another user shows the "self-only" message
  - Verify `nick_changes_guild_user_idx` exists post-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)