### PR TITLE
feat: resilient /randomize summary delivery (v0.6.0)

### DIFF
--- a/.claude/skills/add-name-category/SKILL.md
+++ b/.claude/skills/add-name-category/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: add-name-category
+description: >-
+  Add a new built-in/default nickname category to the chaotic-nick-names Discord
+  bot. Use this whenever the user wants to add, create, expand, or "catalog" a
+  default category of names in this repo — e.g. "add a category of firearms",
+  "new NSFW category for X", "make a list of Y to use as nicknames", "add Z to
+  the default categories". Covers settling the curation decisions, building the
+  list, splicing it into src/categories.json with a validating script, flagging
+  it NSFW in src/data.rs, and verifying with cargo test. Reach for it even if the
+  user doesn't say the word "category" but is clearly adding a pool of names the
+  bot can randomly assign.
+---
+
+# Adding a built-in name category
+
+This bot assigns random Discord nicknames from built-in *categories*. Adding one
+is almost entirely a **data-curation** task: the mechanics are two small edits
+and the existing tests do the enforcement. The hard part is building a good list.
+
+## Where the pieces live
+
+- **`src/categories.json`** — the data. A pretty-printed (2-space indent) map of
+  `{ "slug": ["Name1", "Name2", ...] }`, embedded into the binary at compile
+  time via `include_str!` in `src/data.rs`. Category keys are sorted only for
+  *display* (`builtin_category_names()` sorts a copy), so the key order in the
+  file is cosmetic — but keep it alphabetical for a tidy diff.
+- **`src/data.rs`** — `pub const NSFW: &[&str]` lists the slugs that are 18+.
+  NSFW categories stay in the catalog and work on explicit request
+  (`/randomize category:<slug>`) and show under 🔞 in `/categories`, but are
+  excluded from the default random pool (see `randomize::pick_random_category`).
+- **`scripts/splice_category.py`** (bundled with this skill) — validates a
+  curated list against every invariant below and inserts it into
+  categories.json with a clean diff. Use it; don't hand-edit hundreds of lines.
+
+## Invariants the tests already enforce (so you don't write new tests)
+
+The tests in `src/data.rs` will fail the build if any of these are violated.
+The bundled script checks the same things up front so you catch them in one pass:
+
+- Every name is **≤ 32 chars** (`chars().count()` — Discord's nickname limit).
+- **No leading/trailing whitespace; no empty names.**
+- **No duplicate names within a category.**
+- **Every `NSFW` entry must be a real category** key in categories.json.
+- Category slug should match `^[a-z][a-z0-9_]*$` (lowercase, starts with a
+  letter) — this mirrors `valid_category_key` used for user-added categories.
+
+## Dataset conventions (match the existing data, not just the tests)
+
+The tests don't enforce these, but the existing ~19 categories follow them and
+breaking the pattern reads as sloppy:
+
+- **No `&` and no apostrophes** anywhere. Spell out "and", or abbreviate
+  (e.g. `Smith Wesson`, `HK MP5`). **Avoid periods too** (`Vz 58`, not `Vz. 58`).
+- **Hyphens and spaces are fine** (`AK-47`, `Brown Bess`, `Lee-Enfield`).
+- These are *nicknames*. Each entry should read as recognizable on its own.
+
+## Settle these decisions before curating
+
+Curation quality depends on a few choices. Ask the user (one quick batch is
+fine) unless the request already answers them:
+
+1. **Entry scope** — specific named models only, or also broad historical
+   types/classes? (For the firearms category we included both: `Arquebus` the
+   class *and* `Colt Python` the model.)
+2. **Naming format** — "recognizable form" is usually best: keep a
+   manufacturer/qualifier prefix only when the bare designation would be cryptic
+   (`Colt Python`, `Beretta 92`) but go bare where iconic (`Luger`, `Garand`).
+   Avoid listing the same item under two aliases (pick `Tommy Gun` *or*
+   `Thompson`, not both) — they'd survive the dup test but waste pool slots.
+3. **Size / ambition** — existing categories range ~13 to ~2000 names. A truly
+   "complete" catalog of anything large is impossible to hand-curate accurately;
+   be honest that "complete" realistically means "broad and representative."
+   ~300–600 well-known entries is a solid, accurate default. Say so rather than
+   padding with obscure, possibly-wrong entries.
+
+## Procedure
+
+1. **Pick the slug** (lowercase, underscores), and decide NSFW or not.
+2. **Curate the list** per the decisions above. Write the names to a plain text
+   file, **one per line** (blank lines and `#` comments are ignored). Group with
+   comment headers while drafting — it keeps a long list reviewable and makes
+   gaps obvious.
+3. **Validate + splice** with the bundled script. Dry-run first to see the
+   report and insert point without writing:
+   ```bash
+   python .claude/skills/add-name-category/scripts/splice_category.py \
+       --slug <slug> --names /tmp/<slug>.txt --dry-run
+   # then, if happy:
+   python .claude/skills/add-name-category/scripts/splice_category.py \
+       --slug <slug> --names /tmp/<slug>.txt
+   ```
+   It refuses to run if the slug already exists, prints the count, and confirms
+   the file still parses as JSON afterward.
+4. **If NSFW**, add the slug to the `NSFW` const in `src/data.rs`, keeping it
+   alphabetical:
+   ```rust
+   pub const NSFW: &[&str] = &["<slug>", "serial_killers"];
+   ```
+5. **Verify**: `cargo test`. The data-integrity tests cover correctness — green
+   tests mean the category is well-formed and (if NSFW) correctly flagged. No new
+   test code is needed.
+6. **Review the diff**: it should be exactly one JSON hunk plus (if NSFW) the
+   one-line const change. `git diff --stat` is a fast sanity check.
+7. **Ship** (only when the user asks): per the repo's deploy flow — bump
+   `Cargo.toml`, squash-merge to `master` (which builds the release + GHCR
+   image), then `docker --context proxmox compose pull && up -d`.
+
+## Worked example
+
+The `firearms` category (NSFW, 418 entries spanning Hand Cannon → Arquebus →
+flintlock muskets → cartridge revolvers → bolt rifles → machine guns → SMGs →
+assault rifles → modern pistols) was built exactly this way. Its curation
+decisions (entry scope, naming, size) and era coverage are written up in
+[`docs/firearms-category.md`](../../../docs/firearms-category.md) — a good
+concrete reference for the choices a category like this involves.

--- a/.claude/skills/add-name-category/scripts/splice_category.py
+++ b/.claude/skills/add-name-category/scripts/splice_category.py
@@ -42,7 +42,7 @@ def load_names(path):
     names = []
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
-            s = line.rstrip("\n")
+            s = line.rstrip("\r\n")  # strip both LF and CRLF endings, keep other whitespace
             stripped = s.strip()
             if not stripped or stripped.startswith("#"):
                 continue

--- a/.claude/skills/add-name-category/scripts/splice_category.py
+++ b/.claude/skills/add-name-category/scripts/splice_category.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validate a curated name list and splice it into src/categories.json.
+
+Why this exists
+---------------
+categories.json is a pretty-printed `{ "slug": ["Name", ...] }` map embedded
+into the binary at compile time. The Rust tests in src/data.rs enforce a set of
+invariants on every name. This script checks those *same* invariants in Python
+BEFORE writing, so you find problems in one fast pass instead of via a failing
+`cargo test`, and it inserts the new block at its alphabetical key position
+while leaving every other byte of the file untouched — a clean, reviewable diff
+(re-dumping the whole JSON would reformat and churn all 4000+ lines).
+
+Usage
+-----
+    # names file: one name per line; blank lines and lines starting with # ignored
+    python splice_category.py --slug firearms --names firearms.txt
+
+    # validate + show where it would insert, without writing:
+    python splice_category.py --slug firearms --names firearms.txt --dry-run
+
+    # point at a different repo checkout:
+    python splice_category.py --slug X --names X.txt --json /path/to/src/categories.json
+
+The NSFW flag is a SEPARATE one-line edit to src/data.rs (add the slug to the
+`NSFW` const) — this script only touches categories.json. See the SKILL.md.
+"""
+import argparse
+import json
+import re
+import sys
+
+SLUG_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+KEY_LINE_RE = re.compile(r'^  "([a-z0-9_]+)": \[')
+# Mirror src/commands/categories.rs::valid_category_key and the dataset's own
+# punctuation habits (no & or apostrophes anywhere in the existing data).
+MAX_LEN = 32  # Discord nickname limit (chars, not bytes)
+BANNED = ("&", "'")
+
+
+def load_names(path):
+    names = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            s = line.rstrip("\n")
+            stripped = s.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            names.append(s)  # keep as-is so the whitespace check below can catch slop
+    return names
+
+
+def validate(slug, names):
+    errors = []
+    if not SLUG_RE.match(slug):
+        errors.append(f"slug {slug!r} must match ^[a-z][a-z0-9_]*$ (lowercase, starts with a letter)")
+    if not names:
+        errors.append("name list is empty (a category needs at least one name)")
+    seen = {}
+    for i, name in enumerate(names):
+        if name != name.strip():
+            errors.append(f"[{i}] surrounding whitespace: {name!r}")
+        if not name.strip():
+            errors.append(f"[{i}] empty name")
+        if len(name) > MAX_LEN:
+            errors.append(f"[{i}] {len(name)} chars > {MAX_LEN} limit: {name!r}")
+        for ch in BANNED:
+            if ch in name:
+                errors.append(f"[{i}] banned punctuation {ch!r} (dataset uses none): {name!r}")
+        if name in seen:
+            errors.append(f"[{i}] duplicate of [{seen[name]}]: {name!r}")
+        else:
+            seen[name] = i
+    return errors
+
+
+def render_block(slug, names):
+    lines = [f'  "{slug}": [']
+    for j, name in enumerate(names):
+        comma = "," if j < len(names) - 1 else ""
+        lines.append(f"    {json.dumps(name, ensure_ascii=False)}{comma}")
+    lines.append("  ],")  # trailing comma is correct because we insert BEFORE a later key
+    return "\n".join(lines) + "\n"
+
+
+def find_anchor(text, slug):
+    """Return the existing key line to insert *before* (alphabetical order).
+
+    Returns (anchor_line, None) for the normal "insert before a later key" case,
+    or (None, last_close_idx) when the new slug sorts after every existing key
+    (append case, handled specially by the caller).
+    """
+    lines = text.splitlines()
+    keys = [(m.group(1), idx) for idx, line in enumerate(lines)
+            for m in [KEY_LINE_RE.match(line)] if m]
+    for name, idx in keys:
+        if name > slug:
+            return lines[idx], None
+    return None, lines  # append case
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--slug", required=True, help="category key, e.g. firearms")
+    ap.add_argument("--names", required=True, help="text file, one name per line (# comments ok)")
+    ap.add_argument("--json", default="src/categories.json", help="path to categories.json")
+    ap.add_argument("--dry-run", action="store_true", help="validate and report, but do not write")
+    args = ap.parse_args()
+
+    names = load_names(args.names)
+    errors = validate(args.slug, names)
+    if errors:
+        print("VALIDATION FAILED:")
+        for e in errors:
+            print("  " + e)
+        sys.exit(1)
+    print(f"OK: '{args.slug}' has {len(names)} names — all unique, <= {MAX_LEN} chars, clean punctuation.")
+
+    with open(args.json, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    if f'"{args.slug}"' in text:
+        print(f"ERROR: key {args.slug!r} already exists in {args.json}; aborting.")
+        sys.exit(1)
+
+    block = render_block(args.slug, names)
+    anchor, append_lines = find_anchor(text, args.slug)
+
+    if anchor is not None:
+        where = anchor.strip().split('"')[1]
+        print(f"Insert point: alphabetically before existing key '{where}'.")
+        new_text = text.replace(anchor, block + anchor, 1)
+    else:
+        # New slug sorts after all keys: give the previously-last block a trailing
+        # comma and place ours (no trailing comma) just before the closing brace.
+        print("Insert point: after all existing keys (append).")
+        lines = append_lines
+        close_idx = max(i for i, ln in enumerate(lines) if ln.strip() == "]")
+        lines[close_idx] = lines[close_idx] + ","
+        tail = render_block(args.slug, names).rstrip("\n")
+        if tail.endswith("],"):
+            tail = tail[:-1]  # drop the comma for the now-last block
+        lines.insert(close_idx + 1, tail)
+        new_text = "\n".join(lines) + "\n"
+
+    # Always confirm the result is valid JSON and round-trips before committing it.
+    data = json.loads(new_text)
+    assert data[args.slug] == names, "round-trip mismatch"
+    print(f"Result parses: {len(data)} categories; '{args.slug}' = {len(data[args.slug])} names.")
+
+    if args.dry_run:
+        print("--dry-run: not writing.")
+        return
+    with open(args.json, "w", encoding="utf-8") as f:
+        f.write(new_text)
+    print(f"Wrote {args.json}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# Machine-local Claude Code settings (permission allowlists, absolute paths).
+# The shared, checked-in tooling lives under .claude/skills/.
+.claude/settings.local.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic-nick-names"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dashmap 6.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic-nick-names"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "A Discord bot that assigns chaotic nicknames from various categories"
 

--- a/docs/firearms-category.md
+++ b/docs/firearms-category.md
@@ -1,0 +1,72 @@
+# The `firearms` category
+
+`firearms` is a built-in **NSFW** name category (418 entries). Like the other
+18+ categories it stays in the catalog and works on an explicit
+`/randomize category:firearms`, shows under 🔞 in `/categories`, and is excluded
+from the default random pool (`data::NSFW` in `src/data.rs`).
+
+This document records *how* the list was curated, so the reasoning survives — it
+was originally embedded in a one-shot `build_firearms.py` builder script, now
+removed in favour of the reusable workflow in
+[`.claude/skills/add-name-category/`](../.claude/skills/add-name-category/SKILL.md).
+
+## Curation decisions
+
+Three choices shaped the list:
+
+1. **Entry scope — models *and* historic types.** Both specific named models
+   (`Colt Python`, `AK-47`, `M1 Garand`) and broad historical classes
+   (`Arquebus`, `Matchlock`, `Flintlock`, `Blunderbuss`). The class entries are
+   what let the catalog reach "all the way back" to the 1400s rather than
+   starting at the modern era.
+2. **Naming — recognizable form.** Keep a manufacturer/qualifier prefix only when
+   the bare designation would be cryptic (`Colt Python`, `Beretta 92`, `AK-47`),
+   but go bare where the name is already iconic (`Luger`, `Tommy Gun`, `Garand`,
+   `Arquebus`). The same physical gun is never listed under two aliases (e.g.
+   `Tommy Gun` *or* `Thompson`, not both) — duplicates pass the uniqueness test
+   but waste random-pool slots.
+3. **Size — broad and historically spanning (~400–600).** A truly *complete*
+   catalog of every firearm ever made runs to tens of thousands and can't be
+   hand-curated accurately, so "complete" here means representative breadth, not
+   exhaustiveness. 418 entries is comparable to the `cars` (262) / `spices` (417)
+   categories.
+
+## Era / type coverage
+
+The list sweeps the whole history of small arms, roughly:
+
+- **Ignition-era types & oddities** — hand cannon, arquebus, matchlock,
+  wheellock, snaphance, miquelet, flintlock, caplock, blunderbuss, plus historic
+  curios (Puckle gun, Nock gun, punt gun, duck-foot pistol, Gyrojet, Welrod).
+- **Named muskets & early rifles** — Brown Bess, Charleville, Kentucky/Jaeger
+  rifles, Whitworth, Dreyse needle gun, Chassepot.
+- **Breechloaders & single-shot cartridge rifles** — Sharps, Spencer, Henry,
+  Martini-Henry, rolling block.
+- **Lever / pump repeaters** — the Winchester 1866→1907 line, Marlins, Savage 99.
+- **Bolt-action military & sporting** — Mauser (Gewehr 98 / Kar98k), Mosin-Nagant,
+  Lee-Enfield, Springfield 1903, Arisaka, Carcano, plus modern sporters.
+- **Machine guns** — Gatling, Maxim, Vickers, Lewis, M2 Browning, MG 34/42,
+  Minigun, and historic precursors (mitrailleuse, Nordenfelt, coffee-mill gun).
+- **Submachine guns** — MP 18/40, Tommy gun, Sten, PPSh-41, Uzi, HK MP5, MAC-10.
+- **Semi-auto / battle rifles & DMRs** — Garand, M14, FN FAL, HK G3, SKS, Dragunov.
+- **Assault rifles** — StG 44, the AK family, M16/M4/AR-15, FAMAS, AUG, SCAR, etc.
+- **Shotguns** — Winchester 1897, Remington 870, Mossberg 500, SPAS-12, plus
+  types (coach gun, double barrel, sawed-off, lupara).
+- **Semi-auto pistols** — Borchardt C93, Mauser C96, Luger, Colt 1911, Glock,
+  SIG, CZ, HK, Desert Eagle.
+- **Revolvers** — the Colt line (Paterson → Peacemaker → Python), S&W, Webley,
+  Nagant, Ruger, LeMat.
+- **Precision / anti-materiel** — Barrett M82, AWP, TAC-50, and historic
+  anti-tank rifles (PTRD-41, Boys).
+
+## Conventions enforced
+
+Every name satisfies the invariants the `src/data.rs` tests check — ≤ 32 chars,
+no surrounding whitespace, non-empty, unique within the category — and follows
+the dataset's punctuation habits: **no `&`** (spell out or abbreviate, e.g.
+`Smith Wesson`, `HK MP5`), **no apostrophes**, **no periods** (`Vz 58`, not
+`Vz. 58`); hyphens and spaces are fine.
+
+To add to or rebuild this (or any) category, use the
+[`add-name-category`](../.claude/skills/add-name-category/SKILL.md) skill and its
+`splice_category.py`, which enforce all of the above before writing.

--- a/migrations/003_undelivered_summaries.sql
+++ b/migrations/003_undelivered_summaries.sql
@@ -1,0 +1,18 @@
+-- Background /randomize summaries we could not deliver to the invoking user at
+-- the time: the slash interaction token had expired (very large guild whose run
+-- outlasts Discord's 15-minute window) AND a fallback DM also failed (their DMs
+-- are closed). Rather than drop the result to a log line, we park it here and
+-- surface it — deleting the row — the next time that user runs /randomize in the
+-- guild. See commands::randomize_delivery and
+-- db::{insert_undelivered_summary, take_undelivered_summaries}.
+CREATE TABLE IF NOT EXISTS undelivered_summaries (
+    id          BIGSERIAL    PRIMARY KEY,
+    guild_id    BIGINT       NOT NULL,
+    user_id     BIGINT       NOT NULL,
+    summary     TEXT         NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Delivery is a fetch-and-clear scoped to (guild, user), oldest first.
+CREATE INDEX IF NOT EXISTS undelivered_summaries_guild_user_idx
+    ON undelivered_summaries (guild_id, user_id, created_at);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod history;
 pub mod nick;
 pub mod perms;
 pub mod randomize;
+pub mod randomize_delivery;
 pub mod reset;
 pub mod restore;
 pub mod stats;

--- a/src/commands/randomize.rs
+++ b/src/commands/randomize.rs
@@ -5,6 +5,7 @@ use rand::seq::IndexedRandom;
 use poise::serenity_prelude as serenity;
 
 use crate::commands::perms::require_manage_nicknames;
+use crate::commands::randomize_delivery;
 use crate::{Context, Error};
 // ── Assign names (without-replacement draw, holding write lock briefly) ────
 // Each tuple is (member, new_nick, category_used).
@@ -44,6 +45,26 @@ pub async fn randomize(
     let guild_id = ctx.guild_id().unwrap();
     let http = ctx.serenity_context().http.clone();
     let chaos = chaos.unwrap_or(false);
+
+    // Surface any summaries from an earlier run we couldn't deliver at the time
+    // (the interaction had expired and the user's DMs were closed). Fetch-and-
+    // clear, shown only to the invoker. Best-effort — never blocks the command.
+    {
+        let invoker = ctx.author().id;
+        match crate::db::take_undelivered_summaries(&ctx.data().db, guild_id, invoker.get()).await {
+            Ok(pending) if !pending.is_empty() => {
+                let body = randomize_delivery::render_recovered_summaries(&pending);
+                if let Err(e) = ctx
+                    .send(poise::CreateReply::default().content(body).ephemeral(true))
+                    .await
+                {
+                    tracing::warn!("failed to surface recovered randomize summaries: {e:?}");
+                }
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("failed to load undelivered randomize summaries: {e:?}"),
+        }
+    }
 
     // Collect members (up to 1,000 per page; paginated for larger servers)
     let members = fetch_all_members(guild_id, &http).await?;
@@ -191,8 +212,17 @@ pub async fn randomize(
     }
 
     let total = assignments.len();
-    let channel_id = ctx.channel_id();
     let bot_data = ctx.data().clone();
+    let invoker_id = ctx.author().id;
+    // The interaction token + the progress message's id let the background task
+    // edit that message (an interaction followup) via the webhook route, which
+    // Discord authorises without channel perms — unlike a raw channel POST.
+    // `Copy` Context means this match leaves `ctx` usable below.
+    let interaction_token = match ctx {
+        poise::Context::Application(actx) => Some(actx.interaction.token.clone()),
+        poise::Context::Prefix(_) => None,
+    };
+    let progress_msg_id = prompt.message().await?.id;
 
     prompt
         .edit(
@@ -275,24 +305,18 @@ pub async fn randomize(
             errors,
             "Background randomize task completed"
         );
-        let summary = format!(
-            "✅ Randomization complete! Changed: **{changed}** | ❌ Skipped/errors: **{errors}**"
-        );
-        if let Err(e) = channel_id
-            .send_message(
-                &http,
-                serenity::CreateMessage::new()
-                    .content(summary)
-                    .allowed_mentions(serenity::CreateAllowedMentions::new()),
-            )
-            .await
-        {
-            tracing::warn!(
-                "Failed to send randomize summary to channel {}: {:?}",
-                channel_id,
-                e
-            );
-        }
+        let summary = randomize_delivery::summary_text(changed, errors);
+        let outcome = randomize_delivery::deliver_summary(
+            &http,
+            &bot_data.db,
+            interaction_token.as_deref(),
+            progress_msg_id,
+            invoker_id,
+            guild_id,
+            &summary,
+        )
+        .await;
+        tracing::info!(guild = %guild_id, ?outcome, "Randomize summary delivered");
     });
 
     Ok(())

--- a/src/commands/randomize_delivery.rs
+++ b/src/commands/randomize_delivery.rs
@@ -95,11 +95,20 @@ pub fn render_recovered_summaries(summaries: &[String]) -> String {
     if summaries.is_empty() {
         return String::new();
     }
+    // Cap the list: Discord rejects messages over 2000 chars, and because the
+    // rows are already cleared from the DB by the time we render, a failed send
+    // would lose every recovered summary — not just the overflow. Show at most
+    // LIMIT and tally the rest. (LIMIT * ~65 chars stays well under 2000.)
+    const LIMIT: usize = 15;
     let mut out =
         String::from("📬 Results from an earlier randomize run I couldn't deliver at the time:\n");
-    for s in summaries {
+    for s in summaries.iter().take(LIMIT) {
         out.push_str("\n• ");
         out.push_str(s);
+    }
+    if summaries.len() > LIMIT {
+        let remaining = summaries.len() - LIMIT;
+        out.push_str(&format!("\n\n…and {remaining} more run(s)."));
     }
     out
 }
@@ -151,5 +160,23 @@ mod tests {
         // The flush path only calls this when there is something to show, but a
         // defensive empty-in / empty-out keeps callers from posting a bare header.
         assert_eq!(render_recovered_summaries(&[]), "");
+    }
+
+    #[test]
+    fn render_recovered_caps_long_lists_under_discord_limit() {
+        // Many dead-lettered runs must not blow past Discord's 2000-char message
+        // cap — if the send fails, take_undelivered_summaries has already cleared
+        // the rows, so every recovered summary would be lost, not just truncated.
+        let many: Vec<String> = (0..50).map(|_| summary_text(303, 2)).collect();
+        let out = render_recovered_summaries(&many);
+        assert!(
+            out.chars().count() <= 2000,
+            "exceeded Discord's 2000-char limit: {} chars",
+            out.chars().count()
+        );
+        assert!(
+            out.to_lowercase().contains("more"),
+            "should note that some runs were omitted: {out}"
+        );
     }
 }

--- a/src/commands/randomize_delivery.rs
+++ b/src/commands/randomize_delivery.rs
@@ -1,0 +1,155 @@
+//! Resilient delivery of the background-randomize summary.
+//!
+//! A bulk `/randomize` applies nick edits from a detached `tokio::spawn` that
+//! can outlive the slash interaction, so the final summary has to be delivered
+//! from outside the original command context. The historic approach — a raw
+//! channel POST — fails (HTTP 403 `Missing Access`) whenever the bot lacks
+//! View/Send in the channel the command was invoked from, even though Discord
+//! happily delivered the interaction itself. This module routes the summary
+//! through surfaces that don't depend on channel permissions, falling back in
+//! order: edit the interaction response → DM the invoker → dead-letter it.
+
+use poise::serenity_prelude as serenity;
+use sqlx::PgPool;
+
+/// Which surface actually carried the summary to the user. Returned for logging
+/// and so callers can reason about (and tests can assert) the fallback outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// Edited the original slash-command response (the common, best case).
+    Interaction,
+    /// Fell back to a direct message to the invoker.
+    DirectMessage,
+    /// Parked in the dead-letter table for the user's next `/randomize`.
+    DeadLettered,
+    /// Every path failed, including the database — only logged.
+    Lost,
+}
+
+/// Deliver `summary` to the user who ran `/randomize`, trying the surfaces that
+/// don't depend on the bot's channel permissions, in order. Never returns an
+/// error: the worst case is [`DeliveryOutcome::Lost`], which is logged.
+pub async fn deliver_summary(
+    http: &serenity::Http,
+    db: &PgPool,
+    token: Option<&str>,
+    progress_msg_id: serenity::MessageId,
+    invoker_id: serenity::UserId,
+    guild_id: serenity::GuildId,
+    summary: &str,
+) -> DeliveryOutcome {
+    // 1. Edit the "Randomizing…" progress message in place. After `defer()` that
+    //    message is an interaction *followup* (not the `@original` deferred
+    //    placeholder), so we edit it by id through the interaction webhook —
+    //    Discord authorises this by token, so the bot needing View/Send in the
+    //    invoking channel is irrelevant, which is exactly the failure we are
+    //    fixing. Only works while the token is live (~15 min from invocation).
+    if let Some(token) = token {
+        let builder = serenity::CreateInteractionResponseFollowup::new()
+            .content(summary)
+            .allowed_mentions(serenity::CreateAllowedMentions::new());
+        match http
+            .edit_followup_message(token, progress_msg_id, &builder, Vec::new())
+            .await
+        {
+            Ok(_) => return DeliveryOutcome::Interaction,
+            Err(e) => tracing::debug!(
+                "randomize summary: followup edit failed (token likely expired): {e:?}"
+            ),
+        }
+    }
+
+    // 2. DM the invoker. Fails if they have DMs closed (HTTP 403, code 50007).
+    match invoker_id.create_dm_channel(http).await {
+        Ok(dm) => {
+            let msg = serenity::CreateMessage::new()
+                .content(summary)
+                .allowed_mentions(serenity::CreateAllowedMentions::new());
+            match dm.id.send_message(http, msg).await {
+                Ok(_) => return DeliveryOutcome::DirectMessage,
+                Err(e) => tracing::debug!("randomize summary: DM send failed: {e:?}"),
+            }
+        }
+        Err(e) => tracing::debug!("randomize summary: opening DM channel failed: {e:?}"),
+    }
+
+    // 3. Dead-letter it, to be surfaced on the user's next /randomize.
+    match crate::db::insert_undelivered_summary(db, guild_id, invoker_id.get(), summary).await {
+        Ok(()) => DeliveryOutcome::DeadLettered,
+        Err(e) => {
+            tracing::warn!("randomize summary could not be delivered or persisted (lost): {e:?}");
+            DeliveryOutcome::Lost
+        }
+    }
+}
+
+/// The user-facing summary line for a completed bulk randomize.
+pub fn summary_text(changed: u32, errors: u32) -> String {
+    format!("✅ Randomization complete! Changed: **{changed}** | ❌ Skipped/errors: **{errors}**")
+}
+
+/// Render any summaries that were dead-lettered earlier (because we couldn't
+/// reach the user at the time) into a single message, surfaced the next time the
+/// user interacts. Empty in → empty out, so callers never post a bare header.
+pub fn render_recovered_summaries(summaries: &[String]) -> String {
+    if summaries.is_empty() {
+        return String::new();
+    }
+    let mut out =
+        String::from("📬 Results from an earlier randomize run I couldn't deliver at the time:\n");
+    for s in summaries {
+        out.push_str("\n• ");
+        out.push_str(s);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_text_reports_changed_and_error_counts() {
+        let s = summary_text(303, 2);
+        assert!(s.contains("**303**"), "should show the changed count: {s}");
+        assert!(s.contains("**2**"), "should show the error count: {s}");
+        assert!(
+            s.to_lowercase().contains("complete"),
+            "should read as a completion message: {s}"
+        );
+    }
+
+    #[test]
+    fn summary_text_handles_zero_errors() {
+        let s = summary_text(10, 0);
+        assert!(s.contains("**10**"));
+        assert!(s.contains("**0**"));
+    }
+
+    #[test]
+    fn render_recovered_lists_each_summary_under_a_header() {
+        let out = render_recovered_summaries(&[
+            "First run done".to_string(),
+            "Second run done".to_string(),
+        ]);
+        assert!(
+            out.contains("First run done"),
+            "must include each summary: {out}"
+        );
+        assert!(
+            out.contains("Second run done"),
+            "must include each summary: {out}"
+        );
+        assert!(
+            out.to_lowercase().contains("earlier"),
+            "needs a header explaining these are delayed/earlier results: {out}"
+        );
+    }
+
+    #[test]
+    fn render_recovered_empty_is_empty_string() {
+        // The flush path only calls this when there is something to show, but a
+        // defensive empty-in / empty-out keeps callers from posting a bare header.
+        assert_eq!(render_recovered_summaries(&[]), "");
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -21,6 +21,7 @@ pub async fn setup(database_url: &str) -> Result<PgPool, sqlx::Error> {
     for sql in [
         include_str!("../migrations/001_initial.sql"),
         include_str!("../migrations/002_feedback.sql"),
+        include_str!("../migrations/003_undelivered_summaries.sql"),
     ] {
         sqlx::raw_sql(sql).execute(&pool).await?;
     }
@@ -547,4 +548,51 @@ pub async fn upsert_feedback(
     .execute(pool)
     .await?;
     Ok(())
+}
+
+// ── Undelivered randomize summaries (dead-letter) ────────────────────────────
+
+/// Park a randomize summary we could not deliver to `user_id` at the time, to be
+/// surfaced on their next `/randomize` in the guild. See
+/// [`crate::commands::randomize_delivery`].
+pub async fn insert_undelivered_summary(
+    pool: &PgPool,
+    guild_id: GuildId,
+    user_id: u64,
+    summary: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO undelivered_summaries (guild_id, user_id, summary) VALUES ($1, $2, $3)",
+    )
+    .bind(guild_id.get().cast_signed())
+    .bind(user_id.cast_signed())
+    .bind(summary)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Fetch **and delete** every parked summary for `(guild_id, user_id)`, oldest
+/// first. The delete-and-return is one statement (a `DELETE … RETURNING` CTE) so
+/// a summary is handed back exactly once even under concurrent calls.
+pub async fn take_undelivered_summaries(
+    pool: &PgPool,
+    guild_id: GuildId,
+    user_id: u64,
+) -> Result<Vec<String>, sqlx::Error> {
+    let rows = sqlx::query(
+        r"
+        WITH deleted AS (
+            DELETE FROM undelivered_summaries
+            WHERE guild_id = $1 AND user_id = $2
+            RETURNING summary, created_at
+        )
+        SELECT summary FROM deleted ORDER BY created_at
+        ",
+    )
+    .bind(guild_id.get().cast_signed())
+    .bind(user_id.cast_signed())
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|r| r.get("summary")).collect())
 }


### PR DESCRIPTION
## Summary

The bulk `/randomize` summary was delivered by a raw channel POST from the
detached background task. When the bot lacks View/Send in the channel the
command was invoked from, that POST fails with HTTP 403 (`50001 Missing Access`)
and the result — how many members were renamed, how many errored — was silently
lost to a `WARN` log. Observed in production: a 303-member run completed, then
`Failed to send randomize summary to channel … Missing Access`.

This routes the summary through surfaces that don't depend on the bot's channel
permissions, with an ordered fallback so the result is never silently dropped.

## How it works

Delivery falls back in order:

1. **Edit the "Randomizing…" message in place** via the interaction token. After
   `defer()` that message is an interaction *followup*, edited by id through the
   interaction webhook — Discord authorises this by token, so channel View/Send
   perms are irrelevant (which is exactly the failure being fixed). Valid for
   ~15 min from invocation.
2. **DM the invoker** if the interaction surface is gone (token expired on a very
   large guild, or an HTTP error).
3. **Dead-letter to Postgres** if the DM also fails (closed DMs). Parked
   summaries are surfaced — and cleared — as an ephemeral message the next time
   that user runs `/randomize`.
4. Only if even the DB write fails (Postgres down) is it logged and dropped.

## Changes

- **`randomize_delivery`** (new module): the `deliver_summary` fallback chain +
  `DeliveryOutcome`, plus pure `summary_text` / `render_recovered_summaries`
  helpers (TDD, unit-tested).
- **`db` + migration `003_undelivered_summaries`**: dead-letter table with
  `insert_undelivered_summary` and an atomic take-and-clear (`DELETE … RETURNING`).
- **`randomize`**: captures the interaction token + progress message id before
  the background spawn; flushes pending dead-lettered summaries at command start.
- **Tooling/docs**: the `add-name-category` skill (`.claude/skills/`) with a
  validating splice script, and `docs/firearms-category.md` documenting the
  firearms category's curation decisions and era coverage (replacing the
  one-shot `build_firearms.py`, removed). `.claude/settings.local.json` is
  gitignored (machine-local).
- **Version**: bumped to `0.6.0` (minor — user-facing change).

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 76 passed (incl. the new pure-helper tests)
- `cargo fmt --check` — clean

The DB queries and the HTTP fallback chain are integration-level (CI has no
Postgres), so they're verified by compile + manual rather than unit tests,
matching the existing `db.rs` convention.

**Manual check:** run `/randomize` from a channel the bot can't post in and
confirm the summary still lands (it edits the progress message) instead of 403-ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
